### PR TITLE
fix: don't truncate kubectl -o json output

### DIFF
--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -1458,12 +1458,32 @@ fn atom_matches(a: &Atom, ctx: &ExecCtx) -> bool {
         Atom::Exit(ExitMatch::Ok) => ctx.exit_code == 0,
         Atom::Exit(ExitMatch::Failed) => ctx.exit_code != 0,
         Atom::Level(l) => *l == ctx.level,
-        // Exact token, or the `--flag=value` / `-o=value` form — a guard for
-        // `-o` / `--output` must also fire on `--output=json`. Split on `=`
-        // (not a prefix match) so `--stat` never matches `--statistics`.
-        Atom::Flag(f) => ctx.args.iter().any(|arg| {
-            arg == f || arg.split_once('=').is_some_and(|(name, _)| name == f)
+        Atom::Flag(f) => flag_matches(f, ctx.args),
+    }
+}
+
+/// Match a flag guard against the invoked args.
+///
+/// Two shapes:
+/// - presence — `--stat` / `-o`: true if any arg is that flag, in either the
+///   bare (`--stat`) or `--flag=value` form (`--output=json` matches `--output`).
+/// - flag + value — `-o yaml` / `--output json`: true if the flag carries that
+///   value, written `-o yaml` (two tokens), `-o=yaml`, or glued short `-oyaml`.
+///
+/// Split on `=` rather than prefix-matching so `--stat` never matches
+/// `--statistics`. This is what lets a kubectl `get` rule treat `-o yaml`
+/// (prune) differently from `-o json` (pass through byte-exact).
+fn flag_matches(spec: &str, args: &[String]) -> bool {
+    match spec.split_once(char::is_whitespace) {
+        None => args.iter().any(|a| {
+            a == spec || a.split_once('=').is_some_and(|(name, _)| name == spec)
         }),
+        Some((flag, value)) => {
+            let value = value.trim();
+            args.windows(2).any(|w| w[0] == flag && w[1] == value)
+                || args.iter().any(|a| a == &format!("{flag}={value}"))
+                || (flag.len() == 2 && args.iter().any(|a| a == &format!("{flag}{value}")))
+        }
     }
 }
 
@@ -2402,6 +2422,25 @@ diff:
         let stats = vec!["--statistics".to_string()];
         let ctx = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &stats };
         assert_eq!(execute(&rs, &ctx, "1\n2\n3\n").unwrap(), "1\n2\n");
+    }
+
+    #[test]
+    fn flag_guard_matches_flag_with_value() {
+        // `-o yaml` must fire on the two-token form, `-o=yaml`, and glued
+        // `-oyaml` — but NOT on `-o json`. This lets the kubectl get rule
+        // prune `-o yaml` while passing `-o json` through byte-exact.
+        let rs = parse_ok("get:\n    if -o yaml: head 1\n    else: raw\n");
+        let input = "a\nb\nc\n";
+        let cases = [
+            (vec!["-o".to_string(), "yaml".to_string()], "a\n"),
+            (vec!["-o=yaml".to_string()], "a\n"),
+            (vec!["-oyaml".to_string()], "a\n"),
+            (vec!["-o".to_string(), "json".to_string()], input), // else → raw
+        ];
+        for (args, want) in cases {
+            let ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &args };
+            assert_eq!(execute(&rs, &ctx, input).unwrap(), want, "args={args:?}");
+        }
     }
 
     #[test]

--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -1458,7 +1458,12 @@ fn atom_matches(a: &Atom, ctx: &ExecCtx) -> bool {
         Atom::Exit(ExitMatch::Ok) => ctx.exit_code == 0,
         Atom::Exit(ExitMatch::Failed) => ctx.exit_code != 0,
         Atom::Level(l) => *l == ctx.level,
-        Atom::Flag(f) => ctx.args.iter().any(|arg| arg == f),
+        // Exact token, or the `--flag=value` / `-o=value` form — a guard for
+        // `-o` / `--output` must also fire on `--output=json`. Split on `=`
+        // (not a prefix match) so `--stat` never matches `--statistics`.
+        Atom::Flag(f) => ctx.args.iter().any(|arg| {
+            arg == f || arg.split_once('=').is_some_and(|(name, _)| name == f)
+        }),
     }
 }
 
@@ -2369,6 +2374,34 @@ diff:
         assert_eq!(execute(&rs, &ultra_stat, input).unwrap(), "1\n");
         assert_eq!(execute(&rs, &full_stat, input).unwrap(), "1\n2\n");
         assert_eq!(execute(&rs, &plain, input).unwrap(), "1\n2\n3\n");
+    }
+
+    #[test]
+    fn flag_guard_matches_equals_value_form() {
+        // A `--output` guard must fire on both `--output json` (two tokens)
+        // and `--output=json` (one token). Used so kubectl `get -o json`
+        // bypasses line-truncation that would corrupt the JSON for jq.
+        let rs = parse_ok("get:\n    if --output: raw\n    else: head 1\n");
+        let input = "{\n  \"a\": 1\n}\n";
+        let split = vec!["--output".to_string(), "json".to_string()];
+        let glued = vec!["--output=json".to_string()];
+        let none = vec!["pods".to_string()];
+        let split_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &split };
+        let glued_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &glued };
+        let none_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &none };
+        assert_eq!(execute(&rs, &split_ctx, input).unwrap(), input);
+        assert_eq!(execute(&rs, &glued_ctx, input).unwrap(), input);
+        // No output flag → compaction (head 1) still applies.
+        assert_eq!(execute(&rs, &none_ctx, input).unwrap(), "{\n");
+    }
+
+    #[test]
+    fn flag_guard_equals_does_not_prefix_match() {
+        // `--stat` must NOT match `--statistics` — the `=` split guards this.
+        let rs = parse_ok("diff:\n    if --stat: head 1\n    else: head 2\n");
+        let stats = vec!["--statistics".to_string()];
+        let ctx = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &stats };
+        assert_eq!(execute(&rs, &ctx, "1\n2\n3\n").unwrap(), "1\n2\n");
     }
 
     #[test]

--- a/test-fixtures/plugins/kubectl/kubectl-compact/filter.lf
+++ b/test-fixtures/plugins/kubectl/kubectl-compact/filter.lf
@@ -43,12 +43,19 @@ define clean-yaml:
             print("---")
 
 # ── get ───────────────────────────────────────────────────────────
-# clean-yaml self-detects YAML vs. plain tables, so no conditional
-# dispatch needed — table output passes through unchanged. But `-o json`
-# (and friends) must reach a downstream parser byte-exact: clean-yaml would
-# re-serialize JSON as YAML and `head` would truncate it, so pass through raw.
+# `-o yaml` is the case clean-yaml exists for — prune the server-side noise.
+# Any other explicit format (`-o json`, `jsonpath`, `name`, …) is headed for a
+# downstream parser (`| jq`) and must stay byte-exact, so pass it through raw:
+# clean-yaml would re-serialize JSON as YAML and `head` would truncate it.
+# No `-o` at all → default table, which clean-yaml passes through unchanged.
 get:
-    if -o:
+    if -o yaml:
+        clean-yaml
+        head 200
+    elif --output yaml:
+        clean-yaml
+        head 200
+    elif -o:
         raw
     elif --output:
         raw

--- a/test-fixtures/plugins/kubectl/kubectl-compact/filter.lf
+++ b/test-fixtures/plugins/kubectl/kubectl-compact/filter.lf
@@ -44,10 +44,17 @@ define clean-yaml:
 
 # ── get ───────────────────────────────────────────────────────────
 # clean-yaml self-detects YAML vs. plain tables, so no conditional
-# dispatch needed — table output passes through unchanged.
+# dispatch needed — table output passes through unchanged. But `-o json`
+# (and friends) must reach a downstream parser byte-exact: clean-yaml would
+# re-serialize JSON as YAML and `head` would truncate it, so pass through raw.
 get:
-    clean-yaml
-    head 200
+    if -o:
+        raw
+    elif --output:
+        raw
+    else:
+        clean-yaml
+        head 200
 
 # ── logs ──────────────────────────────────────────────────────────
 logs:


### PR DESCRIPTION
## Problem

`lowfat kubectl get pods -A -o json | jq …` failed with:

```
jq: parse error: Unfinished JSON term at EOF at line 81, column 0
```

The kubectl-compact plugin's `get` arm runs `head 80` (and line-drops written for human/YAML output) at the default level. With `-o json`, that truncates a valid JSON document mid-structure, so jq gets an incomplete doc. The `clean-yaml` variant is just as bad — it re-serializes JSON as YAML, which jq also rejects. lowfat was compacting machine-readable output meant to be parsed byte-exact downstream.

## Fix

- **DSL:** `Atom::Flag` now also matches the `flag=value` form (`--output=json`, `-o=json`), not just exact tokens. Split on `=` (not a prefix match) so `--stat` still won't match `--statistics`.
- **Plugin (`get` arm):** pass `-o` / `--output` output through `raw` so a downstream parser gets byte-exact JSON/YAML. Default (no output flag) still compacts.
- Added lf tests for both flag-matching cases.

> Note: the canonical kubectl-compact plugin lives in the separate `lowfat-plugins` community repo — this PR only carries the in-repo test fixture. A matching change there will be contributed separately.

## Verification

- `-o json`, `--output=json`, `-o=json` → jq parses all items, exit 0
- `kubectl get pods -A` (no format flag) → still compacted
- Full workspace test suite green