### PR TITLE
docs(architecture): correct SQLite metrics data-dir path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,5 +50,6 @@ High-level view of how `lowfat` filters command output between you and your AI a
   the bundled one.
 - **Builtins** — in-process processors (`strip-ansi`, `head`, `grep`,
   `dedup-blank`, `normalize`, …) used as pipeline stages.
-- **SQLite metrics** — `~/.lowfat/data/` tracks token savings and invocation
-  history (powers `lowfat stats` and `lowfat history`).
+- **SQLite metrics** — `$XDG_DATA_HOME/lowfat` (default `~/.local/share/lowfat`,
+  override with `$LOWFAT_DATA`) holds `history.db`, tracking token savings and
+  invocation history (powers `lowfat stats` and `lowfat history`).


### PR DESCRIPTION
The architecture doc lists the SQLite metrics dir as `~/.lowfat/data/`, but that's never the default. Per `crates/lowfat-core/src/config.rs`, the data dir resolves as `$LOWFAT_DATA`, else `$XDG_DATA_HOME/lowfat`, else `~/.local/share/lowfat`, and the file is `history.db`. This updates the doc so users can actually find their database.

Docs-only, no code change.
