### PR TITLE
fix(lf): tolerate early-exiting shell filters on large input

### DIFF
--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -1572,10 +1572,17 @@ fn expand_args(body: &str, args: &[MacroArg]) -> String {
     out
 }
 
-fn run_shell(cmd: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> {
-    let mut child = Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
+/// Spawn a filter child, stream `stdin_data` to it, collect stdout.
+/// Stdin is written from a thread: head-style filters exit before
+/// draining stdin (EPIPE is expected, issue #9), and a threaded write
+/// can't deadlock against an output pipe that fills first.
+fn run_filter_child(
+    mut cmd: Command,
+    what: &str,
+    stdin_data: &str,
+    ctx: &ExecCtx,
+) -> Result<String> {
+    let mut child = cmd
         .env("level", ctx.level.to_string())
         .env("sub", ctx.sub)
         .env("exit", ctx.exit_code.to_string())
@@ -1584,24 +1591,38 @@ fn run_shell(cmd: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .context("spawning sh")?;
+        .with_context(|| format!("spawning {what}"))?;
 
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(stdin_data.as_bytes())
-            .context("writing to sh stdin")?;
-    }
+    let mut stdin = child.stdin.take().expect("stdin is piped");
+    let data = stdin_data.as_bytes().to_vec();
+    let writer = std::thread::spawn(move || match stdin.write_all(&data) {
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+        r => r,
+    });
 
-    let output = child.wait_with_output().context("waiting for sh")?;
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("waiting for {what}"))?;
+    writer
+        .join()
+        .expect("stdin writer panicked")
+        .with_context(|| format!("writing to {what} stdin"))?;
+
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         bail!(
-            "shell exited {}: {}",
+            "{what} exited {}: {}",
             output.status.code().unwrap_or(-1),
             stderr.trim()
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn run_shell(cmd: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> {
+    let mut c = Command::new("sh");
+    c.arg("-c").arg(cmd);
+    run_filter_child(c, "sh", stdin_data, ctx)
 }
 
 fn run_python(body: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> {
@@ -1618,34 +1639,9 @@ fn has_pep723_header(body: &str) -> bool {
 }
 
 fn run_python_plain(body: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> {
-    let mut child = Command::new("python3")
-        .arg("-c")
-        .arg(body)
-        .env("level", ctx.level.to_string())
-        .env("sub", ctx.sub)
-        .env("exit", ctx.exit_code.to_string())
-        .env("args", ctx.args.join(" "))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("spawning python3")?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(stdin_data.as_bytes())
-            .context("writing to python stdin")?;
-    }
-    let output = child.wait_with_output().context("waiting for python")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "python exited {}: {}",
-            output.status.code().unwrap_or(-1),
-            stderr.trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    let mut c = Command::new("python3");
+    c.arg("-c").arg(body);
+    run_filter_child(c, "python3", stdin_data, ctx)
 }
 
 /// PEP 723: write the body to a temp file and let `uv run --script` resolve
@@ -1667,33 +1663,9 @@ fn run_python_uv(body: &str, stdin_data: &str, ctx: &ExecCtx) -> Result<String> 
         .ok_or_else(|| anyhow!("non-UTF8 temp path"))?
         .to_string();
 
-    let mut child = Command::new("uv")
-        .args(["run", "--script", &path])
-        .env("level", ctx.level.to_string())
-        .env("sub", ctx.sub)
-        .env("exit", ctx.exit_code.to_string())
-        .env("args", ctx.args.join(" "))
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("spawning uv (is `uv` installed?)")?;
-
-    if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(stdin_data.as_bytes())
-            .context("writing to uv stdin")?;
-    }
-    let output = child.wait_with_output().context("waiting for uv")?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        bail!(
-            "uv exited {}: {}",
-            output.status.code().unwrap_or(-1),
-            stderr.trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    let mut c = Command::new("uv");
+    c.args(["run", "--script", &path]);
+    run_filter_child(c, "uv", stdin_data, ctx)
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -2172,6 +2144,20 @@ foo:
         );
         let out = execute(&rs, &ctx("foo", Level::Full), "a\nb\n").unwrap();
         assert_eq!(out.trim_end(), "1 a\n2 b");
+    }
+
+    #[test]
+    fn exec_shell_early_exit_on_large_input() {
+        let rs = parse_ok(
+            r#"
+diff:
+    shell: head -n 1
+"#,
+        );
+        let line = "+ a line of diff content that pads out the stream\n";
+        let input = line.repeat(50_000); // ~2.5MB, over every platform's threshold
+        let out = execute(&rs, &ctx("diff", Level::Full), &input).unwrap();
+        assert_eq!(out, line);
     }
 
     #[test]

--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -1593,7 +1593,10 @@ fn run_filter_child(
         .spawn()
         .with_context(|| format!("spawning {what}"))?;
 
-    let mut stdin = child.stdin.take().expect("stdin is piped");
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("{what}: stdin not piped"))?;
     let data = stdin_data.as_bytes().to_vec();
     let writer = std::thread::spawn(move || match stdin.write_all(&data) {
         Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
@@ -1605,7 +1608,7 @@ fn run_filter_child(
         .with_context(|| format!("waiting for {what}"))?;
     writer
         .join()
-        .expect("stdin writer panicked")
+        .map_err(|_| anyhow!("{what} stdin writer panicked"))?
         .with_context(|| format!("writing to {what} stdin"))?;
 
     if !output.status.success() {

--- a/crates/lowfat-runner/src/process.rs
+++ b/crates/lowfat-runner/src/process.rs
@@ -37,11 +37,20 @@ impl FilterPlugin for ProcessFilter {
             .spawn()
             .with_context(|| format!("failed to spawn plugin: sh {entry}"))?;
 
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = stdin.write_all(input.raw.as_bytes());
-        }
+        // Threaded write: a filter may exit early or fill its stdout pipe
+        // before stdin drains — a blocking write EPIPEs or deadlocks here
+        // (issue #9; same pattern as lowfat-core's run_filter_child).
+        let writer = child.stdin.take().map(|mut stdin| {
+            let data = input.raw.clone();
+            std::thread::spawn(move || {
+                let _ = stdin.write_all(data.as_bytes());
+            })
+        });
 
         let output = child.wait_with_output()?;
+        if let Some(w) = writer {
+            let _ = w.join();
+        }
         let text = String::from_utf8_lossy(&output.stdout).to_string();
 
         Ok(FilterOutput {

--- a/crates/lowfat-runner/src/process.rs
+++ b/crates/lowfat-runner/src/process.rs
@@ -42,14 +42,17 @@ impl FilterPlugin for ProcessFilter {
         // (issue #9; same pattern as lowfat-core's run_filter_child).
         let writer = child.stdin.take().map(|mut stdin| {
             let data = input.raw.clone();
-            std::thread::spawn(move || {
-                let _ = stdin.write_all(data.as_bytes());
+            std::thread::spawn(move || match stdin.write_all(data.as_bytes()) {
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => Ok(()),
+                r => r,
             })
         });
 
         let output = child.wait_with_output()?;
         if let Some(w) = writer {
-            let _ = w.join();
+            w.join()
+                .map_err(|_| anyhow::anyhow!("plugin stdin writer panicked"))?
+                .with_context(|| format!("writing to plugin stdin: {entry}"))?;
         }
         let text = String::from_utf8_lossy(&output.stdout).to_string();
 

--- a/crates/lowfat-runner/tests/e2e_plugin.rs
+++ b/crates/lowfat-runner/tests/e2e_plugin.rs
@@ -543,3 +543,62 @@ fi
     assert!(result.text.contains("ERROR (exit 1)"), "should show error on exit 1");
     assert!(result.text.contains("something broke"), "should preserve raw on error");
 }
+
+// ---------------------------------------------------------------------------
+// User plugins on large input (issue #9) — loaded the way the runner loads
+// them: discovery + HybridRunner, covering both .sh and .lf entry points.
+// ---------------------------------------------------------------------------
+
+fn load_user_plugin(name: &str, entry_file: &str, body: &str) -> Box<dyn FilterPlugin> {
+    let root = std::env::temp_dir().join(format!("lowfat-user-{name}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let dir = root.join(name).join(format!("{name}-compact"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let manifest = format!(
+        "[plugin]\nname = \"{name}-compact\"\nversion = \"0.1.0\"\ncommands = [\"{name}\"]\n"
+    );
+    std::fs::write(dir.join("lowfat.toml"), manifest).unwrap();
+    std::fs::write(dir.join(entry_file), body).unwrap();
+
+    let plugins = lowfat_plugin::discovery::discover_plugins(&root);
+    let plugin = plugins
+        .iter()
+        .find(|p| p.manifest.plugin.name == format!("{name}-compact"))
+        .expect("user plugin discovered");
+    lowfat_runner::runner::HybridRunner::load(plugin).expect("user plugin loads")
+}
+
+fn large_input() -> String {
+    "+ a line of output that pads out the stream\n".repeat(50_000) // ~2.2MB
+}
+
+#[test]
+fn user_sh_plugin_early_exit_on_large_input() {
+    let filter = load_user_plugin("bigsh", "filter.sh", "#!/bin/sh\nhead -n 1\n");
+    let raw = large_input();
+    let result = filter
+        .filter(&make_input(&raw, "bigsh", "", vec![], Level::Full, 0))
+        .unwrap();
+    assert_eq!(result.text.lines().count(), 1);
+}
+
+#[test]
+fn user_sh_plugin_large_output_no_deadlock() {
+    // identity filter: stdout outgrows the pipe buffer while stdin streams
+    let filter = load_user_plugin("bigcat", "filter.sh", "#!/bin/sh\ncat\n");
+    let raw = large_input();
+    let result = filter
+        .filter(&make_input(&raw, "bigcat", "", vec![], Level::Full, 0))
+        .unwrap();
+    assert_eq!(result.text.len(), raw.len());
+}
+
+#[test]
+fn user_lf_plugin_early_exit_on_large_input() {
+    let filter = load_user_plugin("biglf", "filter.lf", "*:\n    shell: head -n 1\n");
+    let raw = large_input();
+    let result = filter
+        .filter(&make_input(&raw, "biglf", "", vec![], Level::Full, 0))
+        .unwrap();
+    assert_eq!(result.text.lines().count(), 1);
+}

--- a/crates/lowfat-runner/tests/lf_plugins.rs
+++ b/crates/lowfat-runner/tests/lf_plugins.rs
@@ -170,6 +170,19 @@ fn git_diff_stat_fallback() {
 }
 
 #[test]
+fn git_diff_large_input_no_broken_pipe() {
+    let plugin = bundled_dir().join("git/git-compact");
+    let sample = std::fs::read_to_string(plugin.join("samples/git-diff-full.txt")).unwrap();
+    let large = sample.repeat(200); // ~2.2MB, over every platform's pipe threshold
+
+    let out = run_lf(&plugin.join("filter.lf"), &large, "diff", Level::Full);
+
+    // must stay at the 200-line cap, not fall back to the raw stream
+    let lines = out.lines().count();
+    assert!(lines <= 200, "output not compacted: {lines} lines");
+}
+
+#[test]
 fn cargo_compact_parity() {
     check_plugin(&fixtures_dir().join("cargo/cargo-compact"), 10.0);
 }


### PR DESCRIPTION
- write subprocess stdin from a thread; ignore EPIPE — head-style filters (awk exit, head -n) close stdin before draining it
- remove the write/read deadlock risk when child output outgrows the pipe buffer (ProcessFilter user plugins too)
- dedupe run_shell/run_python/run_uv into run_filter_child
- regression tests: lf shell op, embedded git-compact on inflated sample, and user plugins (.sh and .lf) via discovery + HybridRunner

Fixes #9 


