### PR TITLE
Honest diff truncation, uncapped lite, JSON structure guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Pick one of:
 }
 ```
 
+The filtering pattern [Anthropic recommends](https://code.claude.com/docs/en/costs#offload-processing-to-hooks-and-skills), but via lowfat.
+
 **Shell integration** — auto-activates inside agent environments (`CLAUDECODE=1`, `CODEX_ENV`), or set `LOWFAT_ENABLE=1` to force it on any shell:
 
 ```sh

--- a/crates/lowfat-core/src/lib.rs
+++ b/crates/lowfat-core/src/lib.rs
@@ -4,5 +4,6 @@ pub mod level;
 pub mod lf;
 pub mod pipeline;
 pub mod redact;
+pub mod structured;
 pub mod tee;
 pub mod tokens;

--- a/crates/lowfat-core/src/structured.rs
+++ b/crates/lowfat-core/src/structured.rs
@@ -1,0 +1,231 @@
+//! Structure-aware guard for JSON-shaped output.
+//!
+//! Line filters can cut JSON mid-structure; broken JSON misleads an agent
+//! worse than verbose JSON. If raw output carries JSON but the filtered
+//! result no longer does, re-compact from the parsed tree instead —
+//! valid by construction, re-parsed as a final check before reaching
+//! the agent.
+//!
+//! Recognised shapes: a single JSON document, NDJSON (one value per
+//! line), and a JSON document followed by non-JSON trailer lines (stderr
+//! is appended to stdout, so warnings often land after the JSON).
+
+use crate::level::Level;
+use serde_json::Value;
+
+/// JSON-shaped output, as detected in raw text.
+enum Shape {
+    Single(Value),
+    NdJson(Vec<Value>),
+    WithTrailer(Value, String),
+}
+
+/// (max array items / NDJSON records, max string chars) per level.
+fn caps(level: Level) -> (usize, usize) {
+    match level {
+        Level::Lite => (500, 2000),
+        Level::Full => (50, 500),
+        Level::Ultra => (10, 120),
+    }
+}
+
+fn is_valid_json(text: &str) -> bool {
+    serde_json::from_str::<serde::de::IgnoredAny>(text.trim()).is_ok()
+}
+
+/// Detect a JSON shape. None = not JSON-shaped, leave the text alone.
+fn analyze(raw: &str) -> Option<Shape> {
+    let t = raw.trim();
+    if !(t.starts_with('{') || t.starts_with('[')) {
+        return None;
+    }
+    if let Ok(v) = serde_json::from_str(t) {
+        return Some(Shape::Single(v));
+    }
+    // NDJSON: every non-blank line is its own value
+    let lines: Vec<&str> = t.lines().map(str::trim).filter(|l| !l.is_empty()).collect();
+    if lines.len() >= 2 {
+        if let Some(vals) = lines.iter().map(|l| serde_json::from_str(l).ok()).collect() {
+            return Some(Shape::NdJson(vals));
+        }
+    }
+    // One document + non-JSON trailer (e.g. appended stderr warnings).
+    // A trailer that itself starts with {/[ means malformed JSON — bail.
+    let mut stream = serde_json::Deserializer::from_str(t).into_iter::<Value>();
+    if let Some(Ok(v)) = stream.next() {
+        let rest = t[stream.byte_offset()..].trim();
+        if !rest.is_empty() && !rest.starts_with('{') && !rest.starts_with('[') {
+            return Some(Shape::WithTrailer(v, rest.to_string()));
+        }
+    }
+    None
+}
+
+/// Cap arrays and long strings, recursively. Omissions become string
+/// markers so the result stays parsable.
+fn prune(v: &Value, level: Level) -> Value {
+    let (max_items, max_str) = caps(level);
+    match v {
+        Value::Array(items) => {
+            let mut out: Vec<Value> = items.iter().take(max_items).map(|x| prune(x, level)).collect();
+            if items.len() > max_items {
+                out.push(Value::String(format!(
+                    "... {} more items (lowfat; LOWFAT_LEVEL=lite for more)",
+                    items.len() - max_items
+                )));
+            }
+            Value::Array(out)
+        }
+        Value::Object(map) => {
+            Value::Object(map.iter().map(|(k, x)| (k.clone(), prune(x, level))).collect())
+        }
+        Value::String(s) if s.chars().count() > max_str => {
+            let cut: String = s.chars().take(max_str).collect();
+            Value::String(format!("{cut}... (+{} chars)", s.chars().count() - max_str))
+        }
+        other => other.clone(),
+    }
+}
+
+fn recompact(shape: &Shape, level: Level) -> Option<String> {
+    let out = match shape {
+        Shape::Single(v) => serde_json::to_string(&prune(v, level)).ok()?,
+        Shape::NdJson(vals) => {
+            let (max_records, _) = caps(level);
+            let mut lines: Vec<String> = vals
+                .iter()
+                .take(max_records)
+                .filter_map(|v| serde_json::to_string(&prune(v, level)).ok())
+                .collect();
+            if vals.len() > max_records {
+                lines.push(format!(
+                    "\"... {} more records (lowfat; LOWFAT_LEVEL=lite for more)\"",
+                    vals.len() - max_records
+                ));
+            }
+            lines.join("\n")
+        }
+        Shape::WithTrailer(v, trailer) => {
+            format!("{}\n{trailer}", serde_json::to_string(&prune(v, level)).ok()?)
+        }
+    };
+    Some(out)
+}
+
+/// If `raw` is JSON-shaped but `filtered` no longer is, return a compacted,
+/// re-validated version built from the raw tree. None = keep `filtered`.
+pub fn guard_json(raw: &str, filtered: &str, level: Level) -> Option<String> {
+    let shape = analyze(raw)?;
+    // Still JSON-shaped (e.g. passthrough, or grep over NDJSON) → keep it.
+    if analyze(filtered).is_some() {
+        return None;
+    }
+    // Re-parse before it reaches the agent; raw is JSON-shaped by premise.
+    match recompact(&shape, level) {
+        Some(out) if analyze(&out).is_some() => Some(out + "\n"),
+        _ => Some(raw.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn big_array_json(n: usize) -> String {
+        let items: Vec<String> = (0..n).map(|i| format!("{{\"id\":{i}}}")).collect();
+        format!("[{}]", items.join(","))
+    }
+
+    fn ndjson(n: usize) -> String {
+        (0..n).map(|i| format!("{{\"id\":{i}}}")).collect::<Vec<_>>().join("\n")
+    }
+
+    #[test]
+    fn non_json_is_ignored() {
+        assert!(guard_json("plain text", "txt", Level::Full).is_none());
+    }
+
+    #[test]
+    fn intact_filtered_json_is_kept() {
+        let raw = r#"{"a": 1}"#;
+        assert!(guard_json(raw, r#"{"a":1}"#, Level::Full).is_none());
+    }
+
+    #[test]
+    fn broken_filtered_json_is_recompacted() {
+        let raw = big_array_json(100);
+        let broken = &raw[..50]; // mid-structure cut, like a line truncation
+        let fixed = guard_json(&raw, broken, Level::Full).unwrap();
+        assert!(is_valid_json(&fixed));
+        assert!(fixed.contains("50 more items"));
+    }
+
+    #[test]
+    fn empty_filtered_json_is_recompacted() {
+        let raw = big_array_json(3);
+        let fixed = guard_json(&raw, "", Level::Full).unwrap();
+        assert!(is_valid_json(&fixed));
+        assert!(fixed.contains("\"id\":0"));
+    }
+
+    #[test]
+    fn array_cap_scales_with_level() {
+        let raw = big_array_json(600);
+        let ultra = guard_json(&raw, "x", Level::Ultra).unwrap();
+        let lite = guard_json(&raw, "x", Level::Lite).unwrap();
+        assert!(ultra.contains("590 more items"));
+        assert!(lite.contains("100 more items"));
+    }
+
+    #[test]
+    fn long_strings_are_capped() {
+        let raw = format!(r#"{{"log": "{}"}}"#, "a".repeat(1000));
+        let fixed = guard_json(&raw, "x", Level::Full).unwrap();
+        assert!(is_valid_json(&fixed));
+        assert!(fixed.contains("(+500 chars)"));
+    }
+
+    #[test]
+    fn nested_structures_stay_valid() {
+        let raw = format!(r#"{{"outer": {{"inner": {}}}}}"#, big_array_json(80));
+        let fixed = guard_json(&raw, "x", Level::Full).unwrap();
+        assert!(is_valid_json(&fixed));
+        assert!(fixed.contains("30 more items"));
+    }
+
+    #[test]
+    fn ndjson_is_recompacted_per_record() {
+        let raw = ndjson(100);
+        let fixed = guard_json(&raw, "{broken", Level::Full).unwrap();
+        for line in fixed.lines() {
+            assert!(is_valid_json(line), "broken record: {line}");
+        }
+        assert!(fixed.contains("50 more records"));
+    }
+
+    #[test]
+    fn grep_over_ndjson_is_kept() {
+        // dropping whole lines keeps NDJSON valid — guard must not interfere
+        let raw = ndjson(10);
+        let grepped = ndjson(3);
+        assert!(guard_json(&raw, &grepped, Level::Full).is_none());
+    }
+
+    #[test]
+    fn json_with_stderr_trailer_is_guarded() {
+        // exit_command appends stderr after stdout
+        let raw = format!("{}\nwarning: deprecated flag\n", big_array_json(80));
+        let fixed = guard_json(&raw, "cut {mid", Level::Full).unwrap();
+        assert!(fixed.contains("30 more items"));
+        assert!(fixed.contains("warning: deprecated flag"));
+        let json_part = fixed.lines().next().unwrap();
+        assert!(is_valid_json(json_part));
+    }
+
+    #[test]
+    fn malformed_json_is_left_alone() {
+        // complete value followed by more JSON = malformed document, not a trailer
+        let raw = r#"{"a":1}{"b":2}{"c":"#;
+        assert!(guard_json(raw, "x", Level::Full).is_none());
+    }
+}

--- a/crates/lowfat-core/src/structured.rs
+++ b/crates/lowfat-core/src/structured.rs
@@ -79,9 +79,14 @@ fn prune(v: &Value, level: Level) -> Value {
         Value::Object(map) => {
             Value::Object(map.iter().map(|(k, x)| (k.clone(), prune(x, level))).collect())
         }
-        Value::String(s) if s.chars().count() > max_str => {
-            let cut: String = s.chars().take(max_str).collect();
-            Value::String(format!("{cut}... (+{} chars)", s.chars().count() - max_str))
+        Value::String(s) => {
+            let n = s.chars().count();
+            if n > max_str {
+                let cut: String = s.chars().take(max_str).collect();
+                Value::String(format!("{cut}... (+{} chars)", n - max_str))
+            } else {
+                v.clone()
+            }
         }
         other => other.clone(),
     }
@@ -116,13 +121,14 @@ fn recompact(shape: &Shape, level: Level) -> Option<String> {
 /// re-validated version built from the raw tree. None = keep `filtered`.
 pub fn guard_json(raw: &str, filtered: &str, level: Level) -> Option<String> {
     let shape = analyze(raw)?;
-    // Still JSON-shaped (e.g. passthrough, or grep over NDJSON) → keep it.
-    if analyze(filtered).is_some() {
+    // Empty is a deliberate filter result (e.g. grep with no matches), and
+    // still-JSON-shaped output (passthrough, grep over NDJSON) is fine.
+    if filtered.trim().is_empty() || analyze(filtered).is_some() {
         return None;
     }
     // Re-parse before it reaches the agent; raw is JSON-shaped by premise.
     match recompact(&shape, level) {
-        Some(out) if analyze(&out).is_some() => Some(out + "\n"),
+        Some(out) if analyze(&out).is_some() => Some(out),
         _ => Some(raw.to_string()),
     }
 }
@@ -161,11 +167,10 @@ mod tests {
     }
 
     #[test]
-    fn empty_filtered_json_is_recompacted() {
-        let raw = big_array_json(3);
-        let fixed = guard_json(&raw, "", Level::Full).unwrap();
-        assert!(is_valid_json(&fixed));
-        assert!(fixed.contains("\"id\":0"));
+    fn empty_filtered_output_is_respected() {
+        // a filter dropping everything is deliberate, not broken structure
+        assert!(guard_json(&big_array_json(3), "", Level::Full).is_none());
+        assert!(guard_json(&ndjson(5), "\n", Level::Full).is_none());
     }
 
     #[test]

--- a/crates/lowfat-plugin/embedded/git/git-compact/BENCHMARK.md
+++ b/crates/lowfat-plugin/embedded/git/git-compact/BENCHMARK.md
@@ -31,12 +31,12 @@ where small invocations dominate:
    `Acked-by:`, `Tested-by:`, `Reported-by:`, `Cc:` are dropped; the 40-hex
    commit hash is shortened to 12-hex (decoration like `(HEAD -> main)` is
    preserved). Helps every `git show` / `git log` row.
-4. **Honest truncation + uncapped lite** (v0.6.10) — when the diff cap
-   hits, a tail marker reports how many files/lines were cut instead of
-   ending silently (silent truncation misleads the LLM reader). `lite` is
-   now the escape hatch the marker points at: no line cap, every
-   hunk/change/context line kept, with only redundant pre-hunk meta
-   (`index`/mode/`---`/`+++`) and blank context lines dropped (~3% on an
-   add-heavy diff, more with many files or renames). The marker costs
-   ~30t on capped diffs; the old behaviour hid thousands of changed lines
-   with no indication.
+4. **Honest truncation + uncapped lite** (lowfat v0.6.10, plugin v0.5.6) —
+   when the diff cap hits, a tail marker reports how many files/lines were
+   cut instead of ending silently (silent truncation misleads the LLM
+   reader). `lite` is now the escape hatch the marker points at: no line
+   cap, every hunk/change/context line kept, with only redundant pre-hunk
+   meta (`index`/mode/rename/copy/similarity/`---`/`+++`) and blank
+   context lines dropped (~3% on an add-heavy diff, more with many files
+   or renames). The marker costs ~30t on capped diffs; the old behaviour
+   hid thousands of changed lines with no indication.

--- a/crates/lowfat-plugin/embedded/git/git-compact/BENCHMARK.md
+++ b/crates/lowfat-plugin/embedded/git/git-compact/BENCHMARK.md
@@ -4,14 +4,14 @@ Run: `sh bench.sh`
 
 | Sample | Level | Input | Output | Saved | % |
 |---|---|---|---|---|---|
-| git-diff-full | full | 2,782t | 1,690t | 1,092t | 39% |
+| git-diff-full | full | 2,782t | 1,743t | 1,039t | 37% |
 | git-diff-full | ultra | 2,782t | 121t | 2,661t | **95%** |
 | git-log-full | full | 910t | 178t | 732t | 80% |
 | git-log-full | ultra | 910t | 86t | 824t | **90%** |
-| git-show-full | full | 1,192t | 629t | 563t | 47% |
+| git-show-full | full | 1,192t | 630t | 562t | 47% |
 | git-show-full | ultra | 1,192t | 116t | 1,076t | **90%** |
-| git-status-full | full | 127t | 5t | 122t | **96%** |
-| git-status-full | ultra | 127t | 5t | 122t | **96%** |
+| git-status-full | full | 127t | 49t | 78t | 61% |
+| git-status-full | ultra | 127t | 33t | 94t | **74%** |
 
 ## Optimizations beyond static samples
 
@@ -31,3 +31,12 @@ where small invocations dominate:
    `Acked-by:`, `Tested-by:`, `Reported-by:`, `Cc:` are dropped; the 40-hex
    commit hash is shortened to 12-hex (decoration like `(HEAD -> main)` is
    preserved). Helps every `git show` / `git log` row.
+4. **Honest truncation + uncapped lite** (v0.6.10) — when the diff cap
+   hits, a tail marker reports how many files/lines were cut instead of
+   ending silently (silent truncation misleads the LLM reader). `lite` is
+   now the escape hatch the marker points at: no line cap, every
+   hunk/change/context line kept, with only redundant pre-hunk meta
+   (`index`/mode/`---`/`+++`) and blank context lines dropped (~3% on an
+   add-heavy diff, more with many files or renames). The marker costs
+   ~30t on capped diffs; the old behaviour hid thousands of changed lines
+   with no indication.

--- a/crates/lowfat-plugin/embedded/git/git-compact/filter.lf
+++ b/crates/lowfat-plugin/embedded/git/git-compact/filter.lf
@@ -11,20 +11,31 @@ define abbrev-hash:
 
 # State machine: drop pre-hunk metadata (--- +++ index mode), drop
 # unchanged context, strip @@ function-context tail when ultra.
+# Past the cap, keep counting so the tail marker reports what was cut.
 define compact-diff(limit):
     shell: |
         awk -v lim=$1 -v lvl=$level '
-          BEGIN { in_hunk=0; n=0 }
-          n>=lim { exit }
-          /^diff / { in_hunk=0; print; n++; next }
+          BEGIN { in_hunk=0; n=0; xf=0; xl=0 }
+          /^diff / { in_hunk=0
+                     if (n>=lim) { xf++; next }
+                     print; n++; next }
           /^@@ /  { in_hunk=1
+                    if (n>=lim) { xl++; next }
                     if (lvl=="ultra" && match($0,/ @@/))
                         print substr($0,1,RSTART+2)
                     else print
                     n++; next }
           lvl=="ultra" { next }
-          in_hunk && /^[+-]/ { print; n++ }
+          in_hunk && /^[+-]/ { if (n>=lim) { xl++; next }
+                               print; n++ }
+          END { if (xf || xl)
+                    printf "... [git-compact: truncated; %d more files, %d more lines omitted - use LOWFAT_LEVEL=lite for the full diff]\n", xf, xl }
         '
+
+# Pre-hunk meta duplicates the `diff --git` path. `index` may end without
+# a mode, hence own anchor; --- / +++ keep the space guard for `--` lines.
+define drop-index-meta:
+    drop /^(index [0-9a-f]+\.\.[0-9a-f]+( [0-7]+)?$|(new file mode |deleted file mode |old mode |new mode |similarity index |dissimilarity index |rename from |rename to |copy from |copy to |---|\+\+\+) )/
 
 # ── status ────────────────────────────────────────────────────────
 # File entries: long-format indents them with a tab; short/porcelain (`-s`)
@@ -48,6 +59,7 @@ status:
             or "git status: clean"
 
 # ── diff ──────────────────────────────────────────────────────────
+# Lite: uncapped, drops only pre-hunk meta + blank context lines.
 diff:
     if exit failed:
         raw
@@ -55,8 +67,8 @@ diff:
         compact-diff 30
         or-shell: awk 'NF' | head -50
     elif level lite:
-        compact-diff 400
-        or-shell: awk 'NF' | head -50
+        drop-index-meta
+        drop /^ ?[[:space:]]*$/
     else:
         compact-diff 200
         or-shell: awk 'NF' | head -50
@@ -79,12 +91,7 @@ log:
             head 25
 
 # ── show ──────────────────────────────────────────────────────────
-# Lite is permissive — preserve full context (incl. unchanged lines); only
-# strip trailers + abbreviate the hash, and drop pre-hunk index/mode meta
-# which always duplicates the path already on `diff --git`.
-define drop-index-meta:
-    drop /^(index [0-9a-f]+\.\.[0-9a-f]+( [0-7]+)?|new file mode |deleted file mode |old mode |new mode |similarity index |dissimilarity index |rename from |rename to |copy from |copy to |---|\+\+\+) /
-
+# Lite is permissive — only trailers and pre-hunk meta are dropped.
 show:
     match level:
         ultra:

--- a/crates/lowfat-plugin/embedded/git/git-compact/filter.sh
+++ b/crates/lowfat-plugin/embedded/git/git-compact/filter.sh
@@ -2,9 +2,8 @@
 # git-compact — compact git output for LLM contexts.
 # env: $LOWFAT_LEVEL (lite|full|ultra), $LOWFAT_SUBCOMMAND
 #
-# Reference implementation. The shipped binary uses the equivalent native
-# filter at crates/lowfat/src/filters/git.rs — keep both in sync so bench.sh
-# numbers track real behaviour.
+# Reference implementation. The shipped binary embeds filter.lf — keep both
+# in sync so bench.sh numbers and the parity tests track real behaviour.
 
 RAW=$(cat)
 LEVEL="${LOWFAT_LEVEL:-full}"
@@ -18,16 +17,21 @@ SUB="$LOWFAT_SUBCOMMAND"
 #     in lite/full where the LLM benefits from it.
 # State machine tracks `in_hunk` so a removed source line that happens to
 # start with `--- ` (e.g. comment delimiters) isn't misread as the header.
+# Past the cap, keep counting so the tail marker reports what was cut.
 compact_diff_body() {
   level="$1"
   limit="$2"
   awk -v level="$level" -v limit="$limit" '
-    BEGIN { in_hunk = 0; n = 0 }
+    BEGIN { in_hunk = 0; n = 0; xfiles = 0; xlines = 0 }
     {
-      if (n >= limit) exit
-      if (index($0, "diff ") == 1) { in_hunk = 0; print; n++; next }
+      if (index($0, "diff ") == 1) {
+        in_hunk = 0
+        if (n >= limit) { xfiles++; next }
+        print; n++; next
+      }
       if (index($0, "@@ ") == 1) {
         in_hunk = 1
+        if (n >= limit) { xlines++; next }
         if (level == "ultra") {
           # Strip trailing function-context tail: `@@ -A,B +C,D @@ ctx` → `@@ -A,B +C,D @@`
           if (match($0, / @@/)) print substr($0, 1, RSTART + 2)
@@ -39,7 +43,14 @@ compact_diff_body() {
       if (level == "ultra") next
       if (!in_hunk) next
       first = substr($0, 1, 1)
-      if (first == "+" || first == "-") { print; n++ }
+      if (first == "+" || first == "-") {
+        if (n >= limit) { xlines++; next }
+        print; n++
+      }
+    }
+    END {
+      if (xfiles || xlines)
+        printf "... [git-compact: truncated; %d more files, %d more lines omitted - use LOWFAT_LEVEL=lite for the full diff]\n", xfiles, xlines
     }
   '
 }
@@ -56,6 +67,12 @@ abbreviate_commit_hash() {
   sed -E 's/^commit ([0-9a-f]{12})[0-9a-f]{28}/commit \1/'
 }
 
+# Pre-hunk meta duplicates the `diff --git` path. `index` may end without
+# a mode, hence own anchor; --- / +++ keep the space guard for `--` lines.
+drop_index_meta() {
+  grep -vE '^(index [0-9a-f]+\.\.[0-9a-f]+( [0-7]+)?$|(new file mode |deleted file mode |old mode |new mode |similarity index |dissimilarity index |rename from |rename to |copy from |copy to |---|\+\+\+) )'
+}
+
 case "$SUB" in
   status)
     # File entries: long-format indents with a tab; short/porcelain (-s)
@@ -63,42 +80,44 @@ case "$SUB" in
     # ("On branch", "Changes …", "Untracked", "## branch") for staged-vs-
     # unstaged context; ultra strips to file entries only.
     case "$LEVEL" in
-      ultra) result=$(echo "$RAW" | grep -E '^(	|[ MADRCU?!]{2} )' | head -n 15) ;;
-      lite)  result=$(echo "$RAW" | grep -E '^(	|[ MADRCU?!]{2} |## |On branch|Changes|Untracked)' | head -n 60) ;;
-      *)     result=$(echo "$RAW" | grep -E '^(	|[ MADRCU?!]{2} |## |On branch|Changes|Untracked)' | head -n 30) ;;
+      ultra) result=$(printf '%s\n' "$RAW" | grep -E '^(	|[ MADRCU?!]{2} )' | head -n 15) ;;
+      lite)  result=$(printf '%s\n' "$RAW" | grep -E '^(	|[ MADRCU?!]{2} |## |On branch|Changes|Untracked)' | head -n 60) ;;
+      *)     result=$(printf '%s\n' "$RAW" | grep -E '^(	|[ MADRCU?!]{2} |## |On branch|Changes|Untracked)' | head -n 30) ;;
     esac
     if [ -z "$result" ]; then
       echo "git status: clean"
     else
-      echo "$result"
+      printf '%s\n' "$result"
     fi
     ;;
 
   diff)
+    # Lite: uncapped, drops only pre-hunk meta + blank context lines.
+    # printf, not echo — echo may expand \n etc. inside diff content.
     case "$LEVEL" in
-      lite)  body=$(echo "$RAW" | compact_diff_body lite 400)  ;;
-      ultra) body=$(echo "$RAW" | compact_diff_body ultra 30)  ;;
-      *)     body=$(echo "$RAW" | compact_diff_body full 200)  ;;
+      lite)  body=$(printf '%s\n' "$RAW" | drop_index_meta | grep -vE '^ ?[[:space:]]*$')  ;;
+      ultra) body=$(printf '%s\n' "$RAW" | compact_diff_body ultra 30)  ;;
+      *)     body=$(printf '%s\n' "$RAW" | compact_diff_body full 200)  ;;
     esac
     if [ -z "$body" ]; then
       # No diff/@@ markers — likely --stat / --name-only / --shortstat.
       # Compact pass instead of empty-passthrough so we still record savings.
-      echo "$RAW" | awk 'NF' | head -n 50
+      printf '%s\n' "$RAW" | awk 'NF' | head -n 50
     else
-      echo "$body"
+      printf '%s\n' "$body"
     fi
     ;;
 
   log)
     case "$LEVEL" in
       ultra)
-        echo "$RAW" | grep -E '^(commit |    )' | strip_trailers | abbreviate_commit_hash | head -n 10
+        printf '%s\n' "$RAW" | grep -E '^(commit |    )' | strip_trailers | abbreviate_commit_hash | head -n 10
         ;;
       lite)
-        echo "$RAW" | strip_trailers | abbreviate_commit_hash | head -n 50
+        printf '%s\n' "$RAW" | strip_trailers | abbreviate_commit_hash | head -n 50
         ;;
       *)
-        echo "$RAW" | strip_trailers | abbreviate_commit_hash | head -n 25
+        printf '%s\n' "$RAW" | strip_trailers | abbreviate_commit_hash | head -n 25
         ;;
     esac
     ;;
@@ -107,19 +126,18 @@ case "$SUB" in
     case "$LEVEL" in
       ultra)
         # Commit metadata + diffstat only.
-        echo "$RAW" \
+        printf '%s\n' "$RAW" \
           | grep -E '^(commit |Author:|Date:|    |diff --git)' \
           | strip_trailers \
           | abbreviate_commit_hash \
           | head -n 20
         ;;
       lite)
-        # Permissive: drop only commit-message trailers and pre-hunk index/mode
-        # meta (--- a/X / +++ b/X always duplicate the diff --git path).
-        echo "$RAW" \
+        # Permissive: drop only trailers and pre-hunk meta.
+        printf '%s\n' "$RAW" \
           | strip_trailers \
           | abbreviate_commit_hash \
-          | grep -vE '^(index [0-9a-f]+\.\.[0-9a-f]+( [0-7]+)?|new file mode |deleted file mode |old mode |new mode |similarity index |dissimilarity index |rename from |rename to |copy from |copy to |---|\+\+\+) ' \
+          | drop_index_meta \
           | head -n 200
         ;;
       *)
@@ -127,17 +145,17 @@ case "$SUB" in
         # Pre-diff: keep commit headers, drop trailers, abbreviate the long hash.
         # Post-diff: hand off to compact_diff_body so we get the same metadata
         # drops as `git diff` (--- / +++ / index / mode redundancy).
-        if echo "$RAW" | grep -q '^diff '; then
-          pre=$(echo "$RAW" | awk '/^diff / { exit } { print }' \
+        if printf '%s\n' "$RAW" | grep -q '^diff '; then
+          pre=$(printf '%s\n' "$RAW" | awk '/^diff / { exit } { print }' \
             | grep -E '^(commit |Merge:|Author:|Date:|    )' \
             | strip_trailers \
             | abbreviate_commit_hash)
-          post=$(echo "$RAW" | awk '/^diff / { found=1 } found { print }' \
+          post=$(printf '%s\n' "$RAW" | awk '/^diff / { found=1 } found { print }' \
             | compact_diff_body full 100)
-          { [ -n "$pre" ] && echo "$pre"; [ -n "$post" ] && echo "$post"; } | head -n 100
+          { [ -n "$pre" ] && printf '%s\n' "$pre"; [ -n "$post" ] && printf '%s\n' "$post"; } | head -n 100
         else
           # No diff content (e.g. `git show <tag>`) — commit-style output only.
-          echo "$RAW" \
+          printf '%s\n' "$RAW" \
             | grep -E '^(commit |Merge:|Author:|Date:|    )' \
             | strip_trailers \
             | abbreviate_commit_hash \
@@ -148,6 +166,6 @@ case "$SUB" in
     ;;
 
   *)
-    echo "$RAW" | head -n 30
+    printf '%s\n' "$RAW" | head -n 30
     ;;
 esac

--- a/crates/lowfat-plugin/embedded/git/git-compact/lowfat.toml
+++ b/crates/lowfat-plugin/embedded/git/git-compact/lowfat.toml
@@ -1,6 +1,6 @@
 [plugin]
 name = "git-compact"
-version = "0.5.5"
+version = "0.5.6"
 description = "Compact git status/diff/log/show output for LLM contexts"
 commands = ["git"]
 subcommands = ["status", "diff", "log", "show"]

--- a/crates/lowfat-runner/src/runner.rs
+++ b/crates/lowfat-runner/src/runner.rs
@@ -113,7 +113,7 @@ pub fn execute_pipeline(
     // JSON guard: a filter that broke parsable output is worse than verbose
     // output — re-compact from the parsed tree instead.
     if let Some(fixed) = lowfat_core::structured::guard_json(raw, &out, input_template.level) {
-        return Ok(fixed);
+        return Ok(proc_normalize(&fixed));
     }
     Ok(out)
 }

--- a/crates/lowfat-runner/src/runner.rs
+++ b/crates/lowfat-runner/src/runner.rs
@@ -108,7 +108,14 @@ pub fn execute_pipeline(
     }
 
     // Final cleanup: trim trailing whitespace, collapse blank lines
-    Ok(proc_normalize(&text))
+    let out = proc_normalize(&text);
+
+    // JSON guard: a filter that broke parsable output is worse than verbose
+    // output — re-compact from the parsed tree instead.
+    if let Some(fixed) = lowfat_core::structured::guard_json(raw, &out, input_template.level) {
+        return Ok(fixed);
+    }
+    Ok(out)
 }
 
 /// Execute a command and capture its output.
@@ -189,6 +196,19 @@ mod tests {
         // Should be ANSI-stripped AND truncated
         assert!(!result.contains("\x1b["));
         assert!(result.lines().count() <= 41);
+    }
+
+    #[test]
+    fn json_output_never_truncated_mid_structure() {
+        // `head` would cut this pretty-printed array mid-structure; the
+        // guard must re-compact it into valid JSON instead.
+        let items: Vec<String> = (0..100).map(|i| format!("{{\"id\": {i}}}")).collect();
+        let raw = format!("[\n  {}\n]", items.join(",\n  "));
+        let pipeline = Pipeline::parse("head");
+        let input = make_input(&raw);
+        let result = execute_pipeline(&pipeline, &raw, &input, &HashMap::new()).unwrap();
+        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok(), "broken JSON: {result}");
+        assert!(result.contains("more items"));
     }
 
     #[test]

--- a/crates/lowfat-runner/tests/lf_plugins.rs
+++ b/crates/lowfat-runner/tests/lf_plugins.rs
@@ -177,9 +177,48 @@ fn git_diff_large_input_no_broken_pipe() {
 
     let out = run_lf(&plugin.join("filter.lf"), &large, "diff", Level::Full);
 
-    // must stay at the 200-line cap, not fall back to the raw stream
+    // 200-line cap + 1 truncation marker, no raw fallback
     let lines = out.lines().count();
-    assert!(lines <= 200, "output not compacted: {lines} lines");
+    assert!(lines <= 201, "output not compacted: {lines} lines");
+}
+
+// Capped diffs must say so — silent truncation misleads the LLM reader.
+// Lite is uncapped, dropping only pre-hunk meta and blank context lines.
+#[test]
+fn git_diff_truncation_marker_and_lite_uncapped() {
+    let plugin = bundled_dir().join("git/git-compact");
+    let sample = std::fs::read_to_string(plugin.join("samples/git-diff-full.txt")).unwrap();
+
+    // sample compacts to >200 lines at full, so the marker must fire
+    let full = run_lf(&plugin.join("filter.lf"), &sample, "diff", Level::Full);
+    assert!(
+        full.contains("git-compact: truncated"),
+        "no truncation marker at full:\n{full}"
+    );
+
+    let lite = run_lf(&plugin.join("filter.lf"), &sample, "diff", Level::Lite);
+    assert!(!lite.contains("git-compact: truncated"), "lite must not cap");
+
+    // every hunk header and changed line survives (--- / +++ are meta)
+    let hunks = |s: &str| s.lines().filter(|l| l.starts_with("@@ ")).count();
+    let changes = |s: &str| {
+        s.lines()
+            .filter(|l| {
+                (l.starts_with('+') && !l.starts_with("+++ "))
+                    || (l.starts_with('-') && !l.starts_with("--- "))
+            })
+            .count()
+    };
+    assert_eq!(hunks(&lite), hunks(&sample));
+    assert_eq!(changes(&lite), changes(&sample));
+
+    // redundant pre-hunk meta is gone
+    assert!(!lite.contains("\nindex "), "index meta should be dropped");
+    assert!(!lite.contains("\n--- a/"), "--- meta should be dropped");
+
+    // sh baseline must agree
+    let sh_lite = run_sh(&plugin.join("filter.sh"), &sample, "git", "diff", Level::Lite);
+    assert_eq!(sh_lite.lines().count(), lite.lines().count());
 }
 
 #[test]

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -161,17 +161,25 @@ define abbrev-hash:
 define compact-diff(limit):
     shell: |
         awk -v lim=$1 -v lvl=$level '
-          BEGIN { in_hunk=0; n=0 }
-          n>=lim { exit }
-          /^diff / { in_hunk=0; print; n++; next }
+          BEGIN { in_hunk=0; n=0; xf=0; xl=0 }
+          /^diff / { in_hunk=0
+                     if (n>=lim) { xf++; next }
+                     print; n++; next }
           /^@@ /  { in_hunk=1
+                    if (n>=lim) { xl++; next }
                     if (lvl=="ultra" && match($0,/ @@/))
                         print substr($0,1,RSTART+2)
                     else print
                     n++; next }
           lvl=="ultra" { next }
-          in_hunk && /^[+-]/ { print; n++ }
+          in_hunk && /^[+-]/ { if (n>=lim) { xl++; next }
+                               print; n++ }
+          END { if (xf || xl)
+                    printf "... [git-compact: truncated; %d more files, %d more lines omitted - use LOWFAT_LEVEL=lite for the full diff]\n", xf, xl }
         '
+
+define drop-index-meta:
+    drop /^(index [0-9a-f]+\.\.[0-9a-f]+( [0-7]+)?$|(new file mode |deleted file mode |old mode |new mode |similarity index |dissimilarity index |rename from |rename to |copy from |copy to |---|\+\+\+) )/
 
 status:
     keep /^\t/                      # long-format file entries are tab-indented
@@ -185,8 +193,8 @@ diff:
         compact-diff 30
         or-shell: awk 'NF' | head -50
     elif level lite:
-        compact-diff 400
-        or-shell: awk 'NF' | head -50
+        drop-index-meta              # escape hatch: no caps, only redundant
+        drop /^ ?[[:space:]]*$/      # meta + blank context lines dropped
     else:
         compact-diff 200
         or-shell: awk 'NF' | head -50


### PR DESCRIPTION
## What

**git-compact**
- `compact-diff` emits a tail marker when the cap hits (`... [git-compact: truncated; 34 more files, 3268 more lines omitted - use LOWFAT_LEVEL=lite for the full diff]`) instead of ending silently — silent truncation misleads the LLM reader
- `lite` diff is now the escape hatch: no line cap, keeps every hunk/change/context line, drops only pre-hunk meta (`index`/mode/`---`/`+++`) and blank context lines
- Fixes: `drop-index-meta` missed modeless `index` lines (new/deleted files); `filter.sh` used `echo` on diff content, which expands `\n`/`\t` escapes on macOS sh

**core: structure guard for JSON-shaped output**
- If raw output is JSON-shaped (single document, NDJSON, or JSON followed by stderr warnings) and a filter breaks it, the output is re-compacted from the parsed tree — arrays/strings capped per level, omissions become string markers — then re-validated before printing
- Non-JSON output is unaffected; filters that keep JSON valid (passthrough, grep over NDJSON) are left alone