### PR TITLE
feat: add lowfat-compress crate + post-read hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,12 +487,21 @@ version = "0.6.10"
 dependencies = [
  "anyhow",
  "clap",
+ "lowfat-compress",
  "lowfat-core",
  "lowfat-plugin",
  "lowfat-runner",
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "lowfat-compress"
+version = "0.6.10"
+dependencies = [
+ "regex",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/lowfat-core",
+    "crates/lowfat-compress",
     "crates/lowfat-plugin",
     "crates/lowfat-runner",
     "crates/lowfat",
@@ -27,5 +28,6 @@ clap = { version = "4", features = ["derive"] }
 
 # Internal crates (version required for crates.io publish)
 lowfat-core = { path = "crates/lowfat-core", version = "=0.6.10" }
+lowfat-compress = { path = "crates/lowfat-compress", version = "=0.6.10" }
 lowfat-plugin = { path = "crates/lowfat-plugin", version = "=0.6.10" }
 lowfat-runner = { path = "crates/lowfat-runner", version = "=0.6.10" }

--- a/README.md
+++ b/README.md
@@ -94,10 +94,19 @@ Pick one of:
         "matcher": "Bash",
         "hooks": [{ "type": "command", "command": "lowfat hook" }]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [{ "type": "command", "command": "lowfat post-read" }]
+      }
     ]
   }
 }
 ```
+
+`PreToolUse` rewrites Bash commands through lowfat filters.
+`PostToolUse` compresses file content after Read — strips comments, collapses function bodies, summarizes lock files.
 
 The filtering pattern [Anthropic recommends](https://code.claude.com/docs/en/costs#offload-processing-to-hooks-and-skills), but via lowfat.
 
@@ -155,6 +164,21 @@ lowfat plugin doctor              # check plugins (and pre-install any Python de
 cat samples/git-diff-full.txt | lowfat filter --explain ./filter.lf --sub=diff --level=ultra
 ```
 
+### File content compression (`post-read`)
+
+When Claude reads files, `lowfat post-read` compresses the content before it enters the context:
+
+| Content type | What it does |
+|---|---|
+| **Source code** (Rust, Python, Go, Elixir, JS/TS, Java, Ruby, C/C++, Shell) | Strip comments, normalize blanks; at `ultra`: collapse function bodies to signatures |
+| **Markdown** | Strip badges, HTML comments; truncate code blocks and tables |
+| **HTML** / Vue / Svelte | Strip `<style>`, `<script>`, class attributes; at `ultra`: text extraction only |
+| **JSON / YAML / TOML** | Truncate large arrays, collapse deep nesting |
+| **Lock files** (Cargo.lock, package-lock.json, yarn.lock, ...) | Replace with summary: package count + top deps |
+| **Unknown** | Head + tail with line count |
+
+Compression level follows `LOWFAT_LEVEL` (lite/full/ultra). Files with <10% savings pass through unchanged.
+
 ### Learn more
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — high-level diagram: CLI, Runner, Plugins, Builtins
@@ -181,7 +205,7 @@ core you extend yourself.
 | Built-in commands      | 6 curated (`git`, `docker`, `grep`, `find`, `ls`, `tree`) | 100+ across many ecosystems                       |
 | Custom filters         | `.lf` DSL + shell + Python (PEP 723/uv)                   | TOML DSL                                          |
 | Levels                 | `lite` / `full` / `ultra`                                 | `-l aggressive`, `--ultra-compact`                |
-| File-content filtering | `grep` / `find` plugins                                   | `rtk read` / `smart` (signatures, summaries)      |
+| File-content filtering | `post-read` hook (code, markdown, HTML, data, lock files)  | `rtk read` / `smart` (signatures, summaries)      |
 | Agent integrations     | Claude Code, OpenCode, shell, Pi                          | 14 tools (Claude Code, Copilot, Gemini, Codex, …) |
 | Telemetry              | None — local-only                                         | Opt-in, off by default (anonymous aggregate)      |
 | Savings analytics      | `lowfat stats` / `history` (local)                        | `rtk gain` / `discover` (local)                   |

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ When Claude reads files, `lowfat post-read` compresses the content before it ent
 | **Source code** (Rust, Python, Go, Elixir, JS/TS, Java, Ruby, C/C++, Shell) | Strip comments, normalize blanks; at `ultra`: collapse function bodies to signatures |
 | **Markdown** | Strip badges, HTML comments; truncate code blocks and tables |
 | **HTML** / Vue / Svelte | Strip `<style>`, `<script>`, class attributes; at `ultra`: text extraction only |
-| **JSON / YAML / TOML** | Truncate large arrays, collapse deep nesting |
+| **JSON / JSONC** | Truncate large arrays, collapse deep nesting |
 | **Lock files** (Cargo.lock, package-lock.json, yarn.lock, ...) | Replace with summary: package count + top deps |
 | **Unknown** | Head + tail with line count |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
 </p>
 
-lowfat is a lightweight CLI tool that reduces AI token costs by filtering unnecessary CLI output before it reaches your agent.
+lowfat is a lightweight CLI tool that reduces AI token costs by filtering CLI output and file content before it reaches your agent.
 
 <p align="center">
   <img src="docs/demo.gif" alt="lowfat demo: condensing verbose git output (diff, log) before it reaches the agent" width="700">

--- a/crates/lowfat-compress/Cargo.toml
+++ b/crates/lowfat-compress/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lowfat-compress"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Content-aware file compression for LLM token reduction"
+
+[dependencies]
+regex = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []

--- a/crates/lowfat-compress/src/code.rs
+++ b/crates/lowfat-compress/src/code.rs
@@ -1,0 +1,433 @@
+//! Language-aware source code compression.
+//!
+//! Uses the data-driven LangSpec to strip comments and collapse function bodies.
+//! lite: block comments + blank normalization
+//! full: all comments (keep doc comments) + blank normalization
+//! ultra: + collapse function bodies to signatures
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::detect::{LangId, LangSpec, ScopeStyle};
+use crate::Level;
+
+pub fn compress(content: &str, lang: &LangId, level: Level) -> String {
+    match level {
+        Level::Lite => {
+            let s = strip_block_comments(content, lang.spec);
+            normalize_blanks(&s)
+        }
+        Level::Full => {
+            let s = strip_block_comments(content, lang.spec);
+            let s = strip_line_comments(&s, lang.spec, true);
+            normalize_blanks(&s)
+        }
+        Level::Ultra => {
+            let s = strip_block_comments(content, lang.spec);
+            let s = strip_line_comments(&s, lang.spec, true);
+            let s = normalize_blanks(&s);
+            collapse_bodies(&s, lang.spec)
+        }
+    }
+}
+
+// ── Comment stripping ───────────────────────────────────────────────
+
+fn strip_block_comments(content: &str, spec: &LangSpec) -> String {
+    let (start, end) = match spec.block_comment {
+        Some(pair) => pair,
+        None => return content.to_string(),
+    };
+
+    let mut result = String::with_capacity(content.len());
+    let mut in_block = false;
+    let mut in_string = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Simple string detection: skip lines that are clearly inside a string literal
+        if !in_block {
+            let quote_count = line.matches('"').count();
+            if quote_count % 2 != 0 {
+                in_string = !in_string;
+            }
+            if in_string {
+                result.push_str(line);
+                result.push('\n');
+                continue;
+            }
+        }
+
+        if in_block {
+            if trimmed.contains(end) {
+                in_block = false;
+            }
+            continue;
+        }
+
+        // Keep doc block comments (e.g. /** ... */ or """...""" used as docstrings)
+        if let Some(doc) = spec.doc_comment {
+            if trimmed.starts_with(doc) {
+                result.push_str(line);
+                result.push('\n');
+                continue;
+            }
+        }
+
+        if trimmed.contains(start) && !trimmed.contains(end) {
+            in_block = true;
+            continue;
+        }
+        // Single-line block comment (/* ... */ on one line)
+        if trimmed.contains(start) && trimmed.contains(end) {
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+fn strip_line_comments(content: &str, spec: &LangSpec, keep_doc: bool) -> String {
+    let prefix = match spec.line_comment {
+        Some(p) => p,
+        None => return content.to_string(),
+    };
+
+    let mut result = String::with_capacity(content.len());
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Keep doc comments
+        if keep_doc {
+            if let Some(doc) = spec.doc_comment {
+                if trimmed.starts_with(doc) {
+                    result.push_str(line);
+                    result.push('\n');
+                    continue;
+                }
+            }
+        }
+
+        // Skip pure comment lines
+        if trimmed.starts_with(prefix) {
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+// ── Blank line normalization ────────────────────────────────────────
+
+static MULTI_BLANK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+
+fn normalize_blanks(content: &str) -> String {
+    MULTI_BLANK.replace_all(content, "\n\n").to_string()
+}
+
+// ── Body collapsing (ultra level) ───────────────────────────────────
+
+fn collapse_bodies(content: &str, spec: &LangSpec) -> String {
+    match spec.scope {
+        ScopeStyle::Braces => collapse_braces(content, spec),
+        ScopeStyle::Indentation => collapse_indent(content, spec),
+        ScopeStyle::DoEnd => collapse_do_end(content, spec),
+        ScopeStyle::None => content.to_string(),
+    }
+}
+
+/// Collapse brace-delimited bodies (Rust, Go, JS, Java, C).
+/// Keeps signature line + opening brace, replaces body with "...", keeps closing brace.
+fn collapse_braces(content: &str, spec: &LangSpec) -> String {
+    let sig_re = build_signature_regex(spec);
+    let import_re = build_import_regex(spec);
+    let mut result = String::with_capacity(content.len() / 2);
+    let mut depth: i32 = 0;
+    let mut in_body = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Always keep imports
+        if import_re.is_match(trimmed) {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Detect signature — start tracking body
+        if !in_body && sig_re.is_match(trimmed) {
+            result.push_str(line);
+            result.push('\n');
+            if trimmed.ends_with('{') {
+                in_body = true;
+                depth = 1;
+            }
+            continue;
+        }
+
+        if !in_body {
+            // Opening brace on next line after signature
+            if trimmed == "{" && result.ends_with('\n') {
+                let prev_line = result.trim_end().lines().last().unwrap_or("");
+                if sig_re.is_match(prev_line.trim()) {
+                    result.push_str(line);
+                    result.push('\n');
+                    in_body = true;
+                    depth = 1;
+                    continue;
+                }
+            }
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Inside body — count braces
+        depth += trimmed.matches('{').count() as i32;
+        depth -= trimmed.matches('}').count() as i32;
+
+        if depth <= 0 {
+            result.push_str("    ...\n");
+            result.push_str(line);
+            result.push('\n');
+            in_body = false;
+            depth = 0;
+        }
+    }
+
+    result
+}
+
+/// Collapse indent-based bodies (Python).
+/// Keeps the `def`/`class` line, replaces indented body with "...".
+fn collapse_indent(content: &str, spec: &LangSpec) -> String {
+    let sig_re = build_signature_regex(spec);
+    let import_re = build_import_regex(spec);
+    let mut result = String::with_capacity(content.len() / 2);
+    let mut sig_indent: Option<usize> = None;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Always keep imports
+        if import_re.is_match(trimmed) {
+            sig_indent = None;
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Detect signature
+        if sig_re.is_match(trimmed) {
+            let indent = line.len() - line.trim_start().len();
+            sig_indent = Some(indent);
+            result.push_str(line);
+            result.push('\n');
+            // Emit placeholder
+            let pad: String = " ".repeat(indent + 4);
+            result.push_str(&pad);
+            result.push_str("...\n");
+            continue;
+        }
+
+        // If we're inside a body, skip lines more indented than the signature
+        if let Some(base) = sig_indent {
+            if trimmed.is_empty() {
+                continue;
+            }
+            let indent = line.len() - line.trim_start().len();
+            if indent > base {
+                continue; // skip body
+            }
+            // Back to same or lesser indent — body ended
+            sig_indent = None;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+/// Collapse do/end bodies (Elixir, Ruby).
+fn collapse_do_end(content: &str, spec: &LangSpec) -> String {
+    let sig_re = build_signature_regex(spec);
+    let import_re = build_import_regex(spec);
+    let mut result = String::with_capacity(content.len() / 2);
+    let mut do_depth: i32 = 0;
+    let mut in_body = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if import_re.is_match(trimmed) {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if !in_body && sig_re.is_match(trimmed) {
+            result.push_str(line);
+            result.push('\n');
+            if trimmed.ends_with("do") {
+                in_body = true;
+                do_depth = 1;
+            }
+            continue;
+        }
+
+        if !in_body {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Count do/end nesting
+        if trimmed.ends_with("do") || trimmed == "do" {
+            do_depth += 1;
+        }
+        if trimmed == "end" || trimmed.starts_with("end") {
+            do_depth -= 1;
+            if do_depth <= 0 {
+                result.push_str("    ...\n");
+                result.push_str(line);
+                result.push('\n');
+                in_body = false;
+                do_depth = 0;
+            }
+        }
+    }
+
+    result
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+fn build_signature_regex(spec: &LangSpec) -> Regex {
+    let combined = spec.signature_patterns.join("|");
+    Regex::new(&combined).unwrap_or_else(|_| Regex::new(r"^$").unwrap())
+}
+
+fn build_import_regex(spec: &LangSpec) -> Regex {
+    if spec.import_patterns.is_empty() {
+        return Regex::new(r"^\x00$").unwrap(); // never matches
+    }
+    let combined = spec.import_patterns.join("|");
+    Regex::new(&combined).unwrap_or_else(|_| Regex::new(r"^\x00$").unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect;
+
+    fn rust_lang() -> LangId {
+        LangId { name: "rust", spec: &detect::RUST }
+    }
+
+    fn python_lang() -> LangId {
+        LangId { name: "python", spec: &detect::PYTHON }
+    }
+
+    #[test]
+    fn rust_strip_comments() {
+        let input = "// comment\nfn main() {\n    println!(\"hi\");\n}\n";
+        let result = compress(input, &rust_lang(), Level::Full);
+        assert!(!result.contains("// comment"));
+        assert!(result.contains("fn main()"));
+    }
+
+    #[test]
+    fn rust_keep_doc_comments() {
+        let input = "/// Doc comment\nfn foo() {}\n";
+        let result = compress(input, &rust_lang(), Level::Full);
+        assert!(result.contains("/// Doc comment"));
+    }
+
+    #[test]
+    fn python_collapse_body() {
+        let input = "import os\n\ndef foo():\n    x = 1\n    return x\n\ndef bar():\n    pass\n";
+        let result = compress(input, &python_lang(), Level::Ultra);
+        assert!(result.contains("def foo():"));
+        assert!(result.contains("def bar():"));
+        assert!(!result.contains("x = 1"));
+        assert!(result.contains("..."));
+    }
+
+    #[test]
+    fn rust_collapse_body() {
+        let input = "use std::io;\n\nfn main() {\n    let x = 1;\n    println!(\"{}\", x);\n}\n";
+        let result = compress(input, &rust_lang(), Level::Ultra);
+        assert!(result.contains("use std::io;"));
+        assert!(result.contains("fn main() {"));
+        assert!(result.contains("..."));
+        assert!(!result.contains("let x = 1"));
+    }
+
+    #[test]
+    fn preserves_imports() {
+        let input = "use std::io;\nuse std::fs;\n\n// helper\nfn helper() {\n    todo!()\n}\n";
+        let result = compress(input, &rust_lang(), Level::Ultra);
+        assert!(result.contains("use std::io;"));
+        assert!(result.contains("use std::fs;"));
+    }
+
+    fn count_tokens(s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+
+    #[test]
+    fn meaningful_savings_on_real_code() {
+        let input = r#"
+// Copyright 2024 Foo Corp
+// Licensed under Apache 2.0
+
+use std::collections::HashMap;
+use std::io::{self, Read};
+
+/// A thing that does stuff
+pub struct Foo {
+    bar: String,
+    baz: i32,
+}
+
+impl Foo {
+    /// Create a new Foo
+    pub fn new(bar: String) -> Self {
+        Self {
+            bar,
+            baz: 0,
+        }
+    }
+
+    // Internal helper
+    fn compute(&self) -> i32 {
+        let mut sum = 0;
+        for i in 0..self.baz {
+            sum += i;
+        }
+        sum
+    }
+}
+
+fn main() {
+    let foo = Foo::new("hello".to_string());
+    println!("{}", foo.compute());
+}
+"#;
+        let result = compress(input, &rust_lang(), Level::Ultra);
+        let savings = 100.0 - (count_tokens(&result) as f64 / count_tokens(input) as f64 * 100.0);
+        assert!(savings > 30.0, "Expected >30% savings, got {:.1}%", savings);
+    }
+}

--- a/crates/lowfat-compress/src/code.rs
+++ b/crates/lowfat-compress/src/code.rs
@@ -77,11 +77,28 @@ fn strip_block_comments(content: &str, spec: &LangSpec) -> String {
         }
 
         if trimmed.contains(start) && !trimmed.contains(end) {
+            // Keep any code before the comment opener
+            if let Some(pos) = line.find(start) {
+                let before = line[..pos].trim_end();
+                if !before.is_empty() {
+                    result.push_str(before);
+                    result.push('\n');
+                }
+            }
             in_block = true;
             continue;
         }
-        // Single-line block comment (/* ... */ on one line)
+        // Single-line block comment (/* ... */ on one line) — strip only the comment
         if trimmed.contains(start) && trimmed.contains(end) {
+            if let (Some(s), Some(e)) = (line.find(start), line.find(end)) {
+                let before = &line[..s];
+                let after = &line[e + end.len()..];
+                let cleaned = format!("{}{}", before.trim_end(), after.trim_start());
+                if !cleaned.trim().is_empty() {
+                    result.push_str(&cleaned);
+                    result.push('\n');
+                }
+            }
             continue;
         }
 

--- a/crates/lowfat-compress/src/data.rs
+++ b/crates/lowfat-compress/src/data.rs
@@ -1,0 +1,123 @@
+//! Data file compression (JSON, YAML, TOML, XML, CSV).
+//!
+//! lite: passthrough (never corrupt structured data)
+//! full: truncate arrays >10 items
+//! ultra: + collapse nested objects to keys only
+
+use crate::Level;
+
+pub fn compress(content: &str, file_path: &str, level: Level) -> String {
+    match level {
+        Level::Lite => content.to_string(),
+        Level::Full => truncate_arrays(content, file_path),
+        Level::Ultra => {
+            let s = truncate_arrays(content, file_path);
+            collapse_deep_nesting(&s)
+        }
+    }
+}
+
+/// Truncate JSON arrays with >10 items to first 3 + count marker.
+fn truncate_arrays(content: &str, file_path: &str) -> String {
+    // Only attempt JSON truncation for JSON files
+    if !file_path.ends_with(".json") && !file_path.ends_with(".jsonc") {
+        return content.to_string();
+    }
+
+    // Parse as JSON value to find large arrays
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return content.to_string();
+    };
+
+    let truncated = truncate_value(value, 10);
+    serde_json::to_string_pretty(&truncated).unwrap_or_else(|_| content.to_string())
+}
+
+fn truncate_value(value: serde_json::Value, max_items: usize) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(arr) => {
+            if arr.len() > max_items {
+                let kept: Vec<serde_json::Value> = arr
+                    .into_iter()
+                    .take(3)
+                    .map(|v| truncate_value(v, max_items))
+                    .collect();
+                let mut result = kept;
+                let remaining = result.len();
+                result.push(serde_json::Value::String(format!(
+                    "... [{} more items]",
+                    max_items + 1 - remaining // approximate
+                )));
+                serde_json::Value::Array(result)
+            } else {
+                serde_json::Value::Array(
+                    arr.into_iter()
+                        .map(|v| truncate_value(v, max_items))
+                        .collect(),
+                )
+            }
+        }
+        serde_json::Value::Object(map) => {
+            let truncated_map: serde_json::Map<String, serde_json::Value> = map
+                .into_iter()
+                .map(|(k, v)| (k, truncate_value(v, max_items)))
+                .collect();
+            serde_json::Value::Object(truncated_map)
+        }
+        other => other,
+    }
+}
+
+/// For ultra: collapse deeply nested objects to key summaries.
+fn collapse_deep_nesting(content: &str) -> String {
+    // Simple line-based approach: if nesting >3 levels of indentation, summarize
+    let mut result = String::with_capacity(content.len());
+    let mut skipped = 0;
+
+    for line in content.lines() {
+        let indent = line.len() - line.trim_start().len();
+        // ~3 levels = 6 spaces (2-space indent) or 12 spaces (4-space)
+        if indent > 8 {
+            skipped += 1;
+            continue;
+        }
+        if skipped > 0 {
+            let pad: String = " ".repeat(indent.saturating_sub(2).max(4));
+            result.push_str(&format!("{}... [{} nested lines]\n", pad, skipped));
+            skipped = 0;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    if skipped > 0 {
+        result.push_str(&format!("    ... [{} nested lines]\n", skipped));
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lite_passes_through() {
+        let input = r#"{"key": "value"}"#;
+        assert_eq!(compress(input, "config.json", Level::Lite), input);
+    }
+
+    #[test]
+    fn truncates_large_json_array() {
+        let input = r#"{"items": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}"#;
+        let result = compress(input, "data.json", Level::Full);
+        assert!(result.contains("more items"));
+        assert!(!result.contains("15"));
+    }
+
+    #[test]
+    fn non_json_passthrough() {
+        let input = "key: value\nlist:\n  - item1\n  - item2\n";
+        assert_eq!(compress(input, "config.yaml", Level::Full), input);
+    }
+}

--- a/crates/lowfat-compress/src/data.rs
+++ b/crates/lowfat-compress/src/data.rs
@@ -1,4 +1,4 @@
-//! Data file compression (JSON, YAML, TOML, XML, CSV).
+//! Data file compression (JSON/JSONC only for now).
 //!
 //! lite: passthrough (never corrupt structured data)
 //! full: truncate arrays >10 items
@@ -36,17 +36,18 @@ fn truncate_arrays(content: &str, file_path: &str) -> String {
 fn truncate_value(value: serde_json::Value, max_items: usize) -> serde_json::Value {
     match value {
         serde_json::Value::Array(arr) => {
-            if arr.len() > max_items {
+            let total = arr.len();
+            if total > max_items {
                 let kept: Vec<serde_json::Value> = arr
                     .into_iter()
                     .take(3)
                     .map(|v| truncate_value(v, max_items))
                     .collect();
+                let shown = kept.len();
                 let mut result = kept;
-                let remaining = result.len();
                 result.push(serde_json::Value::String(format!(
                     "... [{} more items]",
-                    max_items + 1 - remaining // approximate
+                    total - shown
                 )));
                 serde_json::Value::Array(result)
             } else {
@@ -113,6 +114,14 @@ mod tests {
         let result = compress(input, "data.json", Level::Full);
         assert!(result.contains("more items"));
         assert!(!result.contains("15"));
+    }
+
+    #[test]
+    fn truncation_count_is_accurate() {
+        let input = r#"{"items": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15]}"#;
+        let result = compress(input, "data.json", Level::Full);
+        // 15 items, 3 shown → "12 more items"
+        assert!(result.contains("12 more items"), "got: {result}");
     }
 
     #[test]

--- a/crates/lowfat-compress/src/detect.rs
+++ b/crates/lowfat-compress/src/detect.rs
@@ -1,0 +1,254 @@
+//! Content type detection from file extension and heuristics.
+
+use std::path::Path;
+
+/// Detected content type for routing to the appropriate compressor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentType {
+    Code(LangId),
+    Markdown,
+    Html,
+    Data,
+    Lock,
+    Unknown,
+}
+
+/// Language identifier for code files.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LangId {
+    pub name: &'static str,
+    pub spec: &'static LangSpec,
+}
+
+/// Data-driven language specification. One entry per supported language.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LangSpec {
+    pub line_comment: Option<&'static str>,
+    pub block_comment: Option<(&'static str, &'static str)>,
+    pub doc_comment: Option<&'static str>,
+    pub scope: ScopeStyle,
+    pub signature_patterns: &'static [&'static str],
+    pub import_patterns: &'static [&'static str],
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScopeStyle {
+    Braces,
+    Indentation,
+    DoEnd,
+    None,
+}
+
+// ── Language specs ──────────────────────────────────────────────────
+
+pub(crate) static RUST: LangSpec = LangSpec {
+    line_comment: Some("//"),
+    block_comment: Some(("/*", "*/")),
+    doc_comment: Some("///"),
+    scope: ScopeStyle::Braces,
+    signature_patterns: &[
+        r"^\s*(pub\s+)?(async\s+)?(fn|struct|enum|trait|impl|type|mod|const|static)\s+",
+    ],
+    import_patterns: &[r"^\s*use\s+"],
+};
+
+pub(crate) static PYTHON: LangSpec = LangSpec {
+    line_comment: Some("#"),
+    block_comment: Some(("\"\"\"", "\"\"\"")),
+    doc_comment: Some("\"\"\""),
+    scope: ScopeStyle::Indentation,
+    signature_patterns: &[
+        r"^\s*(async\s+)?(def|class)\s+",
+    ],
+    import_patterns: &[r"^\s*(import|from)\s+"],
+};
+
+static GO: LangSpec = LangSpec {
+    line_comment: Some("//"),
+    block_comment: Some(("/*", "*/")),
+    doc_comment: Some("//"),
+    scope: ScopeStyle::Braces,
+    signature_patterns: &[
+        r"^\s*(func|type|var|const)\s+",
+    ],
+    import_patterns: &[r"^\s*import\s+"],
+};
+
+static ELIXIR: LangSpec = LangSpec {
+    line_comment: Some("#"),
+    block_comment: None,
+    doc_comment: Some("@doc"),
+    scope: ScopeStyle::DoEnd,
+    signature_patterns: &[
+        r"^\s*(def|defp|defmodule|defmacro|defguard|defstruct|defprotocol|defimpl)\s+",
+    ],
+    import_patterns: &[r"^\s*(import|alias|use|require)\s+"],
+};
+
+static SHELL: LangSpec = LangSpec {
+    line_comment: Some("#"),
+    block_comment: None,
+    doc_comment: None,
+    scope: ScopeStyle::None,
+    signature_patterns: &[
+        r"^\s*\w+\s*\(\)\s*\{",
+        r"^\s*function\s+\w+",
+    ],
+    import_patterns: &[r"^\s*(\.|source)\s+"],
+};
+
+static JAVASCRIPT: LangSpec = LangSpec {
+    line_comment: Some("//"),
+    block_comment: Some(("/*", "*/")),
+    doc_comment: Some("/**"),
+    scope: ScopeStyle::Braces,
+    signature_patterns: &[
+        r"^\s*(export\s+)?(async\s+)?(function|class|interface|type|enum)\s+",
+        r"^\s*(export\s+)?(const|let|var)\s+\w+\s*=",
+    ],
+    import_patterns: &[r"^\s*import\s+"],
+};
+
+static JAVA: LangSpec = LangSpec {
+    line_comment: Some("//"),
+    block_comment: Some(("/*", "*/")),
+    doc_comment: Some("/**"),
+    scope: ScopeStyle::Braces,
+    signature_patterns: &[
+        r"^\s*(public|private|protected|static|abstract|final|\s)*\s*(class|interface|enum|record)\s+",
+        r"^\s*(public|private|protected|static|abstract|final|\s)*\s*\w+\s+\w+\s*\(",
+    ],
+    import_patterns: &[r"^\s*(import|package)\s+"],
+};
+
+static RUBY: LangSpec = LangSpec {
+    line_comment: Some("#"),
+    block_comment: Some(("=begin", "=end")),
+    doc_comment: None,
+    scope: ScopeStyle::DoEnd,
+    signature_patterns: &[
+        r"^\s*(def|class|module)\s+",
+    ],
+    import_patterns: &[r"^\s*require\s+"],
+};
+
+static C_LANG: LangSpec = LangSpec {
+    line_comment: Some("//"),
+    block_comment: Some(("/*", "*/")),
+    doc_comment: None,
+    scope: ScopeStyle::Braces,
+    signature_patterns: &[
+        r"^\s*(static\s+|extern\s+|inline\s+)*\w+[\s*]+\w+\s*\(",
+        r"^\s*(struct|enum|union|typedef)\s+",
+    ],
+    import_patterns: &[r"^\s*#\s*include\s+"],
+};
+
+// ── Extension → ContentType mapping ────────────────────────────────
+
+pub fn detect(file_path: &str, _content: &str) -> ContentType {
+    let ext = Path::new(file_path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let filename = Path::new(file_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+
+    // Lock files (check filename first)
+    if is_lock_file(filename, &ext) {
+        return ContentType::Lock;
+    }
+
+    match ext.as_str() {
+        // Code
+        "rs" => ContentType::Code(LangId { name: "rust", spec: &RUST }),
+        "py" | "pyw" | "pyi" => ContentType::Code(LangId { name: "python", spec: &PYTHON }),
+        "go" => ContentType::Code(LangId { name: "go", spec: &GO }),
+        "ex" | "exs" => ContentType::Code(LangId { name: "elixir", spec: &ELIXIR }),
+        "sh" | "bash" | "zsh" | "fish" => ContentType::Code(LangId { name: "shell", spec: &SHELL }),
+        "js" | "jsx" | "mjs" | "cjs" => ContentType::Code(LangId { name: "javascript", spec: &JAVASCRIPT }),
+        "ts" | "tsx" | "mts" | "cts" => ContentType::Code(LangId { name: "typescript", spec: &JAVASCRIPT }),
+        "java" | "kt" | "kts" => ContentType::Code(LangId { name: "java", spec: &JAVA }),
+        "rb" => ContentType::Code(LangId { name: "ruby", spec: &RUBY }),
+        "c" | "h" => ContentType::Code(LangId { name: "c", spec: &C_LANG }),
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => ContentType::Code(LangId { name: "cpp", spec: &C_LANG }),
+        "swift" => ContentType::Code(LangId { name: "swift", spec: &C_LANG }),
+        "cs" => ContentType::Code(LangId { name: "csharp", spec: &C_LANG }),
+
+        // Markdown
+        "md" | "markdown" | "mdx" => ContentType::Markdown,
+
+        // HTML-like
+        "html" | "htm" | "vue" | "svelte" => ContentType::Html,
+
+        // Data/config
+        "json" | "jsonc" | "json5" => ContentType::Data,
+        "yaml" | "yml" => ContentType::Data,
+        "toml" => ContentType::Data,
+        "xml" | "svg" => ContentType::Data,
+        "csv" | "tsv" => ContentType::Data,
+        "env" => ContentType::Data,
+
+        _ => ContentType::Unknown,
+    }
+}
+
+fn is_lock_file(filename: &str, ext: &str) -> bool {
+    matches!(
+        filename,
+        "Cargo.lock"
+            | "package-lock.json"
+            | "yarn.lock"
+            | "pnpm-lock.yaml"
+            | "Gemfile.lock"
+            | "poetry.lock"
+            | "Pipfile.lock"
+            | "composer.lock"
+            | "mix.lock"
+    ) || ext == "lock"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_rust() {
+        assert!(matches!(detect("src/main.rs", ""), ContentType::Code(_)));
+    }
+
+    #[test]
+    fn detect_python() {
+        assert!(matches!(detect("app.py", ""), ContentType::Code(_)));
+    }
+
+    #[test]
+    fn detect_markdown() {
+        assert_eq!(detect("README.md", ""), ContentType::Markdown);
+    }
+
+    #[test]
+    fn detect_lock_file() {
+        assert_eq!(detect("Cargo.lock", ""), ContentType::Lock);
+        assert_eq!(detect("package-lock.json", ""), ContentType::Lock);
+    }
+
+    #[test]
+    fn detect_json() {
+        assert_eq!(detect("config.json", ""), ContentType::Data);
+    }
+
+    #[test]
+    fn detect_html() {
+        assert_eq!(detect("index.html", ""), ContentType::Html);
+    }
+
+    #[test]
+    fn detect_unknown() {
+        assert_eq!(detect("file.xyz", ""), ContentType::Unknown);
+    }
+}

--- a/crates/lowfat-compress/src/html.rs
+++ b/crates/lowfat-compress/src/html.rs
@@ -1,0 +1,98 @@
+//! HTML compression — extract meaningful text, strip noise.
+//!
+//! lite: strip <style>, <script>, HTML comments, inline styles
+//! full: + strip class/id/data-* attributes
+//! ultra: + text extraction only (keep structure tags)
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::Level;
+
+static STYLE_BLOCK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<style[^>]*>.*?</style>").unwrap());
+static SCRIPT_BLOCK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<script[^>]*>.*?</script>").unwrap());
+static HTML_COMMENT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+static INLINE_STYLE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\s+style="[^"]*""#).unwrap());
+static CLASS_ATTR: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"\s+(class|id|data-\w+)="[^"]*""#).unwrap());
+static ALL_TAGS: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"<[^>]+>").unwrap());
+static MULTI_SPACE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
+static MULTI_BLANK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+
+pub fn compress(content: &str, level: Level) -> String {
+    match level {
+        Level::Lite => lite(content),
+        Level::Full => full(content),
+        Level::Ultra => ultra(content),
+    }
+}
+
+fn lite(content: &str) -> String {
+    let s = STYLE_BLOCK.replace_all(content, "");
+    let s = SCRIPT_BLOCK.replace_all(&s, "");
+    let s = HTML_COMMENT.replace_all(&s, "");
+    let s = INLINE_STYLE.replace_all(&s, "");
+    MULTI_BLANK.replace_all(&s, "\n\n").to_string()
+}
+
+fn full(content: &str) -> String {
+    let s = lite(content);
+    let s = CLASS_ATTR.replace_all(&s, "");
+    MULTI_BLANK.replace_all(&s, "\n\n").to_string()
+}
+
+fn ultra(content: &str) -> String {
+    let s = full(content);
+    // Strip all tags, keep text content
+    let s = ALL_TAGS.replace_all(&s, " ");
+    let s = MULTI_SPACE.replace_all(&s, " ");
+    // Normalize: trim each line, collapse blanks
+    let result: String = s
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    MULTI_BLANK.replace_all(&result, "\n\n").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_style_and_script() {
+        let input = "<html><head><style>body { color: red; }</style></head><body><script>alert(1);</script><p>Hello</p></body></html>";
+        let result = compress(input, Level::Lite);
+        assert!(!result.contains("color: red"));
+        assert!(!result.contains("alert"));
+        assert!(result.contains("Hello"));
+    }
+
+    #[test]
+    fn strips_class_attributes() {
+        let input = r#"<div class="container mx-auto" id="main" data-testid="root"><p>Text</p></div>"#;
+        let result = compress(input, Level::Full);
+        assert!(!result.contains("container"));
+        assert!(!result.contains("data-testid"));
+        assert!(result.contains("Text"));
+    }
+
+    #[test]
+    fn ultra_extracts_text() {
+        let input = "<h1>Title</h1><p>Some <strong>bold</strong> text.</p><ul><li>Item 1</li><li>Item 2</li></ul>";
+        let result = compress(input, Level::Ultra);
+        assert!(result.contains("Title"));
+        assert!(result.contains("bold"));
+        assert!(result.contains("Item 1"));
+        assert!(!result.contains("<h1>"));
+    }
+}

--- a/crates/lowfat-compress/src/html.rs
+++ b/crates/lowfat-compress/src/html.rs
@@ -19,7 +19,7 @@ static HTML_COMMENT: LazyLock<Regex> =
 static INLINE_STYLE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\s+style="[^"]*""#).unwrap());
 static CLASS_ATTR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"\s+(class|id|data-\w+)="[^"]*""#).unwrap());
+    LazyLock::new(|| Regex::new(r#"\s+(class|id|data-[\w-]+)="[^"]*""#).unwrap());
 static ALL_TAGS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"<[^>]+>").unwrap());
 static MULTI_SPACE: LazyLock<Regex> =

--- a/crates/lowfat-compress/src/html.rs
+++ b/crates/lowfat-compress/src/html.rs
@@ -20,8 +20,9 @@ static INLINE_STYLE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\s+style="[^"]*""#).unwrap());
 static CLASS_ATTR: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\s+(class|id|data-[\w-]+)="[^"]*""#).unwrap());
+// Only match real tags (start with letter/!/?), so prose like "a < b and c > d" survives.
 static ALL_TAGS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"<[^>]+>").unwrap());
+    LazyLock::new(|| Regex::new(r"</?[a-zA-Z!?][^>]*>").unwrap());
 static MULTI_SPACE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
 static MULTI_BLANK: LazyLock<Regex> =
@@ -84,6 +85,14 @@ mod tests {
         assert!(!result.contains("container"));
         assert!(!result.contains("data-testid"));
         assert!(result.contains("Text"));
+    }
+
+    #[test]
+    fn ultra_keeps_comparison_text() {
+        // Regex must not eat "< 10 and a >" as if it were a tag.
+        let input = "<p>5 < 10 and a > b</p>";
+        let result = compress(input, Level::Ultra);
+        assert!(result.contains("5 < 10 and a > b"), "got: {result}");
     }
 
     #[test]

--- a/crates/lowfat-compress/src/lib.rs
+++ b/crates/lowfat-compress/src/lib.rs
@@ -40,6 +40,13 @@ pub fn compress(content: &str, file_path: &str, level: Level) -> String {
         ContentType::Unknown => text::compress(content, level),
     };
 
+    // Never hand back nothing for a file that had content: an all-comment file,
+    // a refs-only .d.ts, or heading-less markdown at ultra can strip to empty —
+    // show it verbatim instead of deleting it from context.
+    if compressed.trim().is_empty() {
+        return content.to_string();
+    }
+
     // Only return compressed if we saved >10%
     if compressed.len() < content.len() * 9 / 10 {
         compressed
@@ -61,5 +68,12 @@ mod tests {
     fn passthrough_when_no_savings() {
         let content = "fn main() {}";
         assert_eq!(compress(content, "main.rs", Level::Full), content);
+    }
+
+    #[test]
+    fn all_comment_file_not_emptied() {
+        // A file that is 100% comments strips to empty — must pass through verbatim.
+        let content = "# license line 1\n# license line 2\n# license line 3\n";
+        assert_eq!(compress(content, "__init__.py", Level::Full), content);
     }
 }

--- a/crates/lowfat-compress/src/lib.rs
+++ b/crates/lowfat-compress/src/lib.rs
@@ -1,0 +1,65 @@
+//! Content-aware file compression for LLM token reduction.
+//!
+//! Routes files by type (code, markdown, HTML, data, lock) and applies
+//! level-appropriate compression. No dependency on lowfat internals.
+
+mod code;
+mod data;
+mod detect;
+mod html;
+mod lock;
+mod markdown;
+mod text;
+
+pub use detect::ContentType;
+
+/// Compression intensity — mirrors lowfat-core's Level without depending on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Level {
+    Lite,
+    Full,
+    Ultra,
+}
+
+/// Compress file content based on file path and intensity level.
+///
+/// Returns compressed content. If compression is not worthwhile (< 10% reduction),
+/// returns the original content unchanged.
+pub fn compress(content: &str, file_path: &str, level: Level) -> String {
+    if content.is_empty() {
+        return String::new();
+    }
+
+    let content_type = detect::detect(file_path, content);
+    let compressed = match content_type {
+        ContentType::Code(lang) => code::compress(content, &lang, level),
+        ContentType::Markdown => markdown::compress(content, level),
+        ContentType::Html => html::compress(content, level),
+        ContentType::Data => data::compress(content, file_path, level),
+        ContentType::Lock => lock::compress(content, file_path),
+        ContentType::Unknown => text::compress(content, level),
+    };
+
+    // Only return compressed if we saved >10%
+    if compressed.len() < content.len() * 9 / 10 {
+        compressed
+    } else {
+        content.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input() {
+        assert_eq!(compress("", "foo.rs", Level::Full), "");
+    }
+
+    #[test]
+    fn passthrough_when_no_savings() {
+        let content = "fn main() {}";
+        assert_eq!(compress(content, "main.rs", Level::Full), content);
+    }
+}

--- a/crates/lowfat-compress/src/lock.rs
+++ b/crates/lowfat-compress/src/lock.rs
@@ -1,0 +1,92 @@
+//! Lock file compression — extreme summarization.
+//!
+//! Lock files are almost pure noise for LLMs. Replace with a summary
+//! of dependency count + top-level deps.
+
+use std::path::Path;
+
+pub fn compress(content: &str, file_path: &str) -> String {
+    let filename = Path::new(file_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("lock");
+
+    let line_count = content.lines().count();
+
+    match filename {
+        "Cargo.lock" => summarize_cargo_lock(content, line_count),
+        "package-lock.json" => summarize_npm_lock(content, line_count),
+        "yarn.lock" => summarize_yarn_lock(content, line_count),
+        _ => summarize_generic(filename, content, line_count),
+    }
+}
+
+fn summarize_cargo_lock(content: &str, line_count: usize) -> String {
+    // Count [[package]] entries
+    let pkg_count = content.matches("[[package]]").count();
+
+    // Extract top-level package names (first few)
+    let names: Vec<&str> = content
+        .lines()
+        .filter(|l| l.starts_with("name = "))
+        .take(10)
+        .map(|l| l.trim_start_matches("name = ").trim_matches('"'))
+        .collect();
+
+    format!(
+        "# Cargo.lock: {} packages ({} lines)\n# Top packages: {}\n# [full lock file omitted — use `cargo tree` for dependency graph]\n",
+        pkg_count,
+        line_count,
+        names.join(", ")
+    )
+}
+
+fn summarize_npm_lock(content: &str, line_count: usize) -> String {
+    // Count "node_modules/" entries (rough package count)
+    let pkg_count = content.matches("node_modules/").count();
+    format!(
+        "// package-lock.json: ~{} packages ({} lines)\n// [full lock file omitted]\n",
+        pkg_count, line_count
+    )
+}
+
+fn summarize_yarn_lock(content: &str, line_count: usize) -> String {
+    // Count top-level entries (lines that don't start with space)
+    let entry_count = content
+        .lines()
+        .filter(|l| !l.starts_with(' ') && !l.is_empty() && !l.starts_with('#'))
+        .count();
+    format!(
+        "# yarn.lock: ~{} entries ({} lines)\n# [full lock file omitted]\n",
+        entry_count, line_count
+    )
+}
+
+fn summarize_generic(filename: &str, _content: &str, line_count: usize) -> String {
+    format!(
+        "# {}: {} lines\n# [lock file omitted — not useful for LLM context]\n",
+        filename, line_count
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cargo_lock_summary() {
+        let input = "[[package]]\nname = \"serde\"\nversion = \"1.0\"\n\n[[package]]\nname = \"tokio\"\nversion = \"1.0\"\n";
+        let result = compress(input, "Cargo.lock");
+        assert!(result.contains("2 packages"));
+        assert!(result.contains("serde"));
+        assert!(!result.contains("version"));
+    }
+
+    #[test]
+    fn generic_lock() {
+        let input = "a = 1\nb = 2\nc = 3\n";
+        let result = compress(input, "Gemfile.lock");
+        assert!(result.contains("3 lines"));
+        assert!(result.contains("omitted"));
+    }
+}

--- a/crates/lowfat-compress/src/markdown.rs
+++ b/crates/lowfat-compress/src/markdown.rs
@@ -1,0 +1,212 @@
+//! Markdown compression — strip noise, keep structure.
+//!
+//! lite: strip badge images, HTML comments, normalize blanks
+//! full: + collapse long code blocks, truncate tables
+//! ultra: + collapse sections to headings + first paragraph
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::Level;
+
+static BADGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\s*\[!\[.*?\]\(.*?\)\]\(.*?\)\s*$").unwrap());
+static HTML_COMMENT_START: &str = "<!--";
+static HTML_COMMENT_END: &str = "-->";
+
+pub fn compress(content: &str, level: Level) -> String {
+    match level {
+        Level::Lite => lite(content),
+        Level::Full => full(content),
+        Level::Ultra => ultra(content),
+    }
+}
+
+fn lite(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut in_html_comment = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        // Strip HTML comments
+        if trimmed.contains(HTML_COMMENT_START) && !trimmed.contains(HTML_COMMENT_END) {
+            in_html_comment = true;
+            continue;
+        }
+        if in_html_comment {
+            if trimmed.contains(HTML_COMMENT_END) {
+                in_html_comment = false;
+            }
+            continue;
+        }
+        if trimmed.contains(HTML_COMMENT_START) && trimmed.contains(HTML_COMMENT_END) {
+            continue;
+        }
+
+        // Strip badge images
+        if BADGE_RE.is_match(trimmed) {
+            continue;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    normalize_blanks(&result)
+}
+
+fn full(content: &str) -> String {
+    let base = lite(content);
+    let mut result = String::with_capacity(base.len());
+    let mut in_code_block = false;
+    let mut code_block_lines = 0;
+    let mut table_rows = 0;
+
+    for line in base.lines() {
+        let trimmed = line.trim();
+
+        // Track fenced code blocks
+        if trimmed.starts_with("```") {
+            if in_code_block {
+                // Closing fence
+                if code_block_lines > 20 {
+                    result.push_str(&format!("    ... [{} lines]\n", code_block_lines));
+                }
+                result.push_str(line);
+                result.push('\n');
+                in_code_block = false;
+                code_block_lines = 0;
+            } else {
+                in_code_block = true;
+                code_block_lines = 0;
+                result.push_str(line);
+                result.push('\n');
+            }
+            continue;
+        }
+
+        if in_code_block {
+            code_block_lines += 1;
+            if code_block_lines <= 20 {
+                result.push_str(line);
+                result.push('\n');
+            }
+            continue;
+        }
+
+        // Truncate tables >10 rows
+        if trimmed.starts_with('|') && trimmed.ends_with('|') {
+            table_rows += 1;
+            if table_rows <= 10 {
+                result.push_str(line);
+                result.push('\n');
+            } else if table_rows == 11 {
+                result.push_str(&format!("| ... [more rows] |\n"));
+            }
+            continue;
+        } else {
+            table_rows = 0;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+fn ultra(content: &str) -> String {
+    let base = full(content);
+    let mut result = String::with_capacity(base.len() / 2);
+    let mut after_heading = false;
+    let mut paragraph_kept = false;
+
+    for line in base.lines() {
+        let trimmed = line.trim();
+
+        // Always keep headings
+        if trimmed.starts_with('#') {
+            result.push_str(line);
+            result.push('\n');
+            after_heading = true;
+            paragraph_kept = false;
+            continue;
+        }
+
+        // Keep first non-empty paragraph after heading
+        if after_heading {
+            if trimmed.is_empty() {
+                if paragraph_kept {
+                    after_heading = false;
+                }
+                result.push('\n');
+                continue;
+            }
+            paragraph_kept = true;
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        // Skip other content at ultra level
+        if trimmed.is_empty() {
+            result.push('\n');
+        }
+    }
+
+    normalize_blanks(&result)
+}
+
+fn normalize_blanks(content: &str) -> String {
+    static MULTI_BLANK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+    MULTI_BLANK.replace_all(content, "\n\n").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_badges() {
+        let input = "# Title\n\n[![CI](https://img.shields.io/badge)](https://ci.example)\n\nContent here.\n";
+        let result = compress(input, Level::Lite);
+        assert!(!result.contains("img.shields.io"));
+        assert!(result.contains("# Title"));
+        assert!(result.contains("Content here"));
+    }
+
+    #[test]
+    fn strips_html_comments() {
+        let input = "# Title\n<!-- TODO: fix this -->\nReal content.\n";
+        let result = compress(input, Level::Lite);
+        assert!(!result.contains("TODO"));
+        assert!(result.contains("Real content"));
+    }
+
+    #[test]
+    fn truncates_code_blocks() {
+        let mut input = String::from("# Code\n\n```rust\n");
+        for i in 0..50 {
+            input.push_str(&format!("let x{} = {};\n", i, i));
+        }
+        input.push_str("```\n");
+
+        let result = compress(&input, Level::Full);
+        assert!(result.contains("```rust"));
+        assert!(result.contains("... ["));
+        assert!(result.contains("lines]"));
+    }
+
+    #[test]
+    fn ultra_keeps_headings_and_first_para() {
+        let input = "# Overview\n\nFirst paragraph here.\n\nSecond paragraph here.\n\n# Next\n\nAnother first.\n\nAnother second.\n";
+        let result = compress(input, Level::Ultra);
+        assert!(result.contains("# Overview"));
+        assert!(result.contains("First paragraph"));
+        assert!(!result.contains("Second paragraph"));
+        assert!(result.contains("# Next"));
+        assert!(result.contains("Another first"));
+    }
+}

--- a/crates/lowfat-compress/src/text.rs
+++ b/crates/lowfat-compress/src/text.rs
@@ -1,0 +1,69 @@
+//! Fallback text compression for unknown file types.
+//!
+//! lite: normalize blanks
+//! full: head + tail with line count
+//! ultra: aggressive head with summary
+
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use crate::Level;
+
+static MULTI_BLANK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+
+pub fn compress(content: &str, level: Level) -> String {
+    match level {
+        Level::Lite => normalize_blanks(content),
+        Level::Full => head_tail(content, 200, 20),
+        Level::Ultra => head_tail(content, 100, 10),
+    }
+}
+
+fn normalize_blanks(content: &str) -> String {
+    MULTI_BLANK.replace_all(content, "\n\n").to_string()
+}
+
+fn head_tail(content: &str, head: usize, tail: usize) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.len() <= head + tail {
+        return normalize_blanks(content);
+    }
+
+    let mut result = String::with_capacity(content.len() / 2);
+    for line in &lines[..head] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    let omitted = lines.len() - head - tail;
+    result.push_str(&format!("\n[... {} lines omitted ...]\n\n", omitted));
+
+    for line in &lines[lines.len() - tail..] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_file_passthrough() {
+        let input = "line1\nline2\nline3\n";
+        assert_eq!(compress(input, Level::Full), input);
+    }
+
+    #[test]
+    fn long_file_truncated() {
+        let input: String = (0..500).map(|i| format!("line {}\n", i)).collect();
+        let result = compress(&input, Level::Full);
+        assert!(result.contains("lines omitted"));
+        assert!(result.contains("line 0"));
+        assert!(result.contains("line 499"));
+        assert!(result.len() < input.len());
+    }
+}

--- a/crates/lowfat/Cargo.toml
+++ b/crates/lowfat/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "CLI binary for lowfat"
+description = "Token-aware output and file content filter for LLM environments"
 
 [[bin]]
 name = "lowfat"

--- a/crates/lowfat/Cargo.toml
+++ b/crates/lowfat/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 lowfat-core = { workspace = true }
+lowfat-compress = { workspace = true }
 lowfat-plugin = { workspace = true }
 lowfat-runner = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/lowfat/src/commands/mod.rs
+++ b/crates/lowfat/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod level;
 pub mod opencode;
 pub mod pipeline;
 pub mod plugin;
+pub mod post_read;
 pub mod rewrite;
 pub mod run;
 pub mod shell_init;

--- a/crates/lowfat/src/commands/post_read.rs
+++ b/crates/lowfat/src/commands/post_read.rs
@@ -1,0 +1,51 @@
+//! PostToolUse hook for Claude Code Read tool.
+//! Reads hook JSON from stdin, compresses file content, outputs hook response.
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+use std::io::Read;
+
+pub fn run() -> Result<()> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("Failed to read stdin")?;
+
+    let payload: Value =
+        serde_json::from_str(&input).context("Failed to parse PostToolUse JSON")?;
+
+    let tool_output = match payload["tool_output"].as_str() {
+        Some(s) if !s.is_empty() => s,
+        _ => return Ok(()), // no content or empty — pass through
+    };
+
+    let file_path = payload["tool_input"]["file_path"].as_str().unwrap_or("");
+    if file_path.is_empty() {
+        return Ok(());
+    }
+
+    // Map lowfat-core Level to lowfat-compress Level
+    let core_level = lowfat_core::config::RunfConfig::resolve().level;
+    let level = match core_level {
+        lowfat_core::level::Level::Lite => lowfat_compress::Level::Lite,
+        lowfat_core::level::Level::Full => lowfat_compress::Level::Full,
+        lowfat_core::level::Level::Ultra => lowfat_compress::Level::Ultra,
+    };
+
+    let compressed = lowfat_compress::compress(tool_output, file_path, level);
+
+    // Only emit if we saved something meaningful
+    if compressed.len() >= tool_output.len() * 9 / 10 {
+        return Ok(()); // <10% savings, not worth rewriting
+    }
+
+    let output = json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "updatedToolOutput": compressed
+        }
+    });
+
+    println!("{}", serde_json::to_string(&output)?);
+    Ok(())
+}

--- a/crates/lowfat/src/commands/post_read.rs
+++ b/crates/lowfat/src/commands/post_read.rs
@@ -18,12 +18,18 @@ fn process_payload(input: &str) -> Result<()> {
     let payload: Value =
         serde_json::from_str(input).context("Failed to parse PostToolUse JSON")?;
 
-    let tool_output = match payload["tool_output"].as_str() {
+    // Read tool delivers content as a structured object:
+    //   tool_response: { type: "text", file: { content, numLines, totalLines, ... } }
+    // Anything else (non-text reads, image/notebook payloads) passes through.
+    let content = match payload["tool_response"]["file"]["content"].as_str() {
         Some(s) if !s.is_empty() => s,
-        _ => return Ok(()), // no content or empty — pass through
+        _ => return Ok(()),
     };
 
-    let file_path = payload["tool_input"]["file_path"].as_str().unwrap_or("");
+    let file_path = payload["tool_input"]["file_path"]
+        .as_str()
+        .or_else(|| payload["tool_response"]["file"]["filePath"].as_str())
+        .unwrap_or("");
     if file_path.is_empty() {
         return Ok(());
     }
@@ -36,17 +42,25 @@ fn process_payload(input: &str) -> Result<()> {
         lowfat_core::level::Level::Ultra => lowfat_compress::Level::Ultra,
     };
 
-    let compressed = lowfat_compress::compress(tool_output, file_path, level);
+    let compressed = lowfat_compress::compress(content, file_path, level);
 
     // Only emit if we saved something meaningful
-    if compressed.len() >= tool_output.len() * 9 / 10 {
+    if compressed.len() >= content.len() * 9 / 10 {
         return Ok(()); // <10% savings, not worth rewriting
     }
+
+    // Echo back the tool_response object with content replaced; keep line counts
+    // consistent so Claude Code's re-render isn't misleading.
+    let mut tool_response = payload["tool_response"].clone();
+    let line_count = compressed.lines().count();
+    tool_response["file"]["content"] = json!(compressed);
+    tool_response["file"]["numLines"] = json!(line_count);
+    tool_response["file"]["totalLines"] = json!(line_count);
 
     let output = json!({
         "hookSpecificOutput": {
             "hookEventName": "PostToolUse",
-            "updatedToolOutput": compressed
+            "updatedToolOutput": tool_response
         }
     });
 
@@ -62,20 +76,33 @@ mod tests {
     fn make_payload(file_path: &str, content: &str) -> String {
         json!({
             "tool_input": {"file_path": file_path},
-            "tool_output": content
+            "tool_response": {"type": "text", "file": {"content": content}}
         })
         .to_string()
     }
 
     #[test]
     fn empty_tool_output_passes_through() {
-        let payload = json!({"tool_input": {"file_path": "x.rs"}, "tool_output": ""}).to_string();
+        let payload = make_payload("x.rs", "");
         assert!(process_payload(&payload).is_ok());
     }
 
     #[test]
     fn missing_file_path_passes_through() {
-        let payload = json!({"tool_input": {}, "tool_output": "some content"}).to_string();
+        let payload = json!({"tool_response": {"file": {"content": "some content"}}}).to_string();
+        // filePath fallback also absent — passes through
+        assert!(process_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn emits_structured_output_for_compressible_file() {
+        // Capture stdout is awkward here; just assert the happy path doesn't error
+        // and that real-shaped lock content is handled. Shape correctness is covered
+        // by the field paths in process_payload (tool_response.file.content).
+        let lock_content = (0..50)
+            .map(|i| format!("[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n", i, i))
+            .collect::<String>();
+        let payload = make_payload("Cargo.lock", &lock_content);
         assert!(process_payload(&payload).is_ok());
     }
 

--- a/crates/lowfat/src/commands/post_read.rs
+++ b/crates/lowfat/src/commands/post_read.rs
@@ -11,8 +11,12 @@ pub fn run() -> Result<()> {
         .read_to_string(&mut input)
         .context("Failed to read stdin")?;
 
+    process_payload(&input)
+}
+
+fn process_payload(input: &str) -> Result<()> {
     let payload: Value =
-        serde_json::from_str(&input).context("Failed to parse PostToolUse JSON")?;
+        serde_json::from_str(input).context("Failed to parse PostToolUse JSON")?;
 
     let tool_output = match payload["tool_output"].as_str() {
         Some(s) if !s.is_empty() => s,
@@ -48,4 +52,52 @@ pub fn run() -> Result<()> {
 
     println!("{}", serde_json::to_string(&output)?);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_payload(file_path: &str, content: &str) -> String {
+        json!({
+            "tool_input": {"file_path": file_path},
+            "tool_output": content
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn empty_tool_output_passes_through() {
+        let payload = json!({"tool_input": {"file_path": "x.rs"}, "tool_output": ""}).to_string();
+        assert!(process_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn missing_file_path_passes_through() {
+        let payload = json!({"tool_input": {}, "tool_output": "some content"}).to_string();
+        assert!(process_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn small_savings_not_emitted() {
+        // Short content won't compress >10%
+        let payload = make_payload("main.rs", "fn main() {}");
+        assert!(process_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn lock_file_compresses() {
+        // Lock files get extreme summarization — guaranteed >10% savings
+        let lock_content = (0..50)
+            .map(|i| format!("[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n", i, i))
+            .collect::<String>();
+        let payload = make_payload("Cargo.lock", &lock_content);
+        assert!(process_payload(&payload).is_ok());
+    }
+
+    #[test]
+    fn invalid_json_returns_error() {
+        assert!(process_payload("not json").is_err());
+    }
 }

--- a/crates/lowfat/src/main.rs
+++ b/crates/lowfat/src/main.rs
@@ -62,6 +62,8 @@ Examples:
     // ── integrations ──────────────────────────────────────────────
     /// Claude Code PreToolUse hook (reads JSON from stdin)
     Hook,
+    /// Claude Code PostToolUse hook for Read tool (compresses file content)
+    PostRead,
     /// Rewrite a command to its lowfat-wrapped form (used by agent plugins)
     #[command(after_help = "\
 Examples:
@@ -253,6 +255,7 @@ fn main() {
         },
         Some(Commands::Level { value }) => commands::level::run(value.as_deref()),
         Some(Commands::Hook) => commands::hook::run(),
+        Some(Commands::PostRead) => commands::post_read::run(),
         Some(Commands::Rewrite { command }) => commands::rewrite::run(&command),
         Some(Commands::Opencode { action }) => match action {
             OpencodeAction::Install => commands::opencode::install(),

--- a/crates/lowfat/src/main.rs
+++ b/crates/lowfat/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(name = "lowfat", version)]
-#[command(about = "Token-aware command filter for LLM environments")]
+#[command(about = "Token-aware output and file content filter for LLM environments")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -51,7 +51,7 @@ based on file type (code, markdown, HTML, data, lock files).
    │  Claude Code reads a file                        │
    │  (PostToolUse hook fires)                        │
    └────────────────────┬─────────────────────────────┘
-                        │ stdin: JSON {tool_input, tool_output}
+                        │ stdin: JSON {tool_input, tool_response}
                         ▼
    ┌───────────────────────────────────────────────────┐
    │           lowfat post-read                       │

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,11 +1,16 @@
 # Architecture
 
-High-level view of how `lowfat` filters command output between you and your AI agent.
+High-level view of how `lowfat` reduces token usage for AI agents via two paths:
+command-output filtering and file-content compression.
+
+## Mode 1: Command Output Filtering
+
+Wraps a shell command, pipes its output through a plugin/builtin pipeline.
 
 ```
        ┌──────────────────────────────────────────┐
-       │  User / AI Agent                         │
-       │  $ lowfat <cmd>   |   Claude hook stdin  │
+       │  AI Agent                                │
+       │  $ lowfat <cmd>                          │
        └────────────────────┬─────────────────────┘
                             │
                             ▼
@@ -36,11 +41,53 @@ High-level view of how `lowfat` filters command output between you and your AI a
                   └─────────────────────┘
 ```
 
+## Mode 2: File Content Compression (Post-Read Hook)
+
+Intercepts Claude Code's `Read` tool output and compresses file content
+based on file type (code, markdown, HTML, data, lock files).
+
+```
+   ┌───────────────────────────────────────────────────┐
+   │  Claude Code reads a file                        │
+   │  (PostToolUse hook fires)                        │
+   └────────────────────┬─────────────────────────────┘
+                        │ stdin: JSON {tool_input, tool_output}
+                        ▼
+   ┌───────────────────────────────────────────────────┐
+   │           lowfat post-read                       │
+   │                                                   │
+   │   parse hook JSON ─▶ detect content type          │
+   │                      ─▶ compress (level-aware)    │
+   │                      ─▶ emit updatedToolOutput    │
+   └──────────────────────────┬────────────────────────┘
+                              │
+                              ▼
+                  ┌──────────────────────┐
+                  │  lowfat-compress     │
+                  │                      │
+                  │  code   → strip docs │
+                  │  md     → trim prose │
+                  │  html   → minify     │
+                  │  data   → summarize  │
+                  │  lock   → digest     │
+                  └──────────────────────┘
+                              │
+                              ▼
+                  ┌─────────────────────┐
+                  │  compressed content │ ──▶ Claude context
+                  └─────────────────────┘
+```
+
 ## Components
 
-- **lowfat CLI** (`crates/lowfat`) — clap entry point, dispatches subcommands.
+- **lowfat CLI** (`crates/lowfat`) — clap entry point, dispatches subcommands
+  (`run`, `post-read`, `stats`, `history`).
 - **lowfat Runner** (`crates/lowfat-runner`) — executes the real command, loads
   plugins via `HybridRunner`, and walks the pipeline stages.
+- **lowfat Compress** (`crates/lowfat-compress`) — content-aware file compression.
+  Routes by detected type (code/markdown/HTML/data/lock) and applies
+  level-appropriate reduction. Standalone crate with no dependency on lowfat
+  internals.
 - **Config** (`crates/lowfat-core`) — resolves `.lowfat` TOML + env vars into a
   `RunfConfig` (level, plugin dir, conditional pipelines).
 - **Plugins** (`crates/lowfat-plugin`) — manifest + `.lf` DSL files. Bundled


### PR DESCRIPTION
- New `lowfat-compress` crate: content-aware file compression
  - Code: language-aware comment stripping + body collapsing (Rust, Python, Go, Elixir, Shell, JS/TS, Java, Ruby, C/C++)
  - Markdown: strip badges, HTML comments, truncate code blocks/tables
  - HTML: strip style/script/attributes, text extraction
  - Data: JSON array truncation, nesting collapse
  - Lock files: extreme summarization
  - Fallback: head + tail with line count
- New `lowfat post-read` command: PostToolUse hook for Claude Code Read tool

## Fixes (post-review hardening)
- **Hook contract**: Read delivers content as a structured `tool_response` object, not a `tool_output` string. The hook now reads `tool_response.file.content` and emits the full object back under `updatedToolOutput` (verified against a real captured payload — without this it compressed nothing).
- **HTML ultra**: tag regex only matches real tags, so prose like `a < b and c > d` is no longer eaten as markup.
- **Empty-output guard**: all-comment files, refs-only `.d.ts`, and heading-less markdown at ultra could strip to nothing; the `>10%` gate didn't catch it (empty *is* >10% smaller). Now passes through verbatim instead of deleting content.

## Verification
- Confirmed live in Claude Code: `Cargo.lock` → 3-line summary, `.d.ts` → verbatim (guard), Python lib file → license stripped / code intact.
- Batch over 1,456 real files (Python/Go/JS/TS/MD/YAML/JSON/lock), 2,912 compressions at Full + Ultra: 0 panics, 0 blowups, 0 empty outputs.
- 282 tests pass.
