### PR TITLE
feat: `include` directive for .lf — share macros across filters

### DIFF
--- a/crates/lowfat-compress/src/code.rs
+++ b/crates/lowfat-compress/src/code.rs
@@ -401,11 +401,17 @@ mod tests {
     use crate::detect;
 
     fn rust_lang() -> LangId {
-        LangId { name: "rust", spec: &detect::RUST }
+        LangId {
+            name: "rust",
+            spec: &detect::RUST,
+        }
     }
 
     fn python_lang() -> LangId {
-        LangId { name: "python", spec: &detect::PYTHON }
+        LangId {
+            name: "python",
+            spec: &detect::PYTHON,
+        }
     }
 
     #[test]
@@ -440,7 +446,10 @@ mod tests {
         let result = compress(input, &python_lang(), Level::Ultra);
         assert!(result.contains("def toposort(data):"), "got:\n{result}");
         assert!(result.contains("def other():"), "got:\n{result}");
-        assert!(!result.contains("Dependencies are expressed"), "docstring leaked:\n{result}");
+        assert!(
+            !result.contains("Dependencies are expressed"),
+            "docstring leaked:\n{result}"
+        );
         assert!(!result.contains("if len(data)"), "body leaked:\n{result}");
     }
 

--- a/crates/lowfat-compress/src/detect.rs
+++ b/crates/lowfat-compress/src/detect.rs
@@ -57,9 +57,7 @@ pub(crate) static PYTHON: LangSpec = LangSpec {
     block_comment: Some(("\"\"\"", "\"\"\"")),
     doc_comment: Some("\"\"\""),
     scope: ScopeStyle::Indentation,
-    signature_patterns: &[
-        r"^\s*(async\s+)?(def|class)\s+",
-    ],
+    signature_patterns: &[r"^\s*(async\s+)?(def|class)\s+"],
     import_patterns: &[r"^\s*(import|from)\s+"],
 };
 
@@ -68,9 +66,7 @@ static GO: LangSpec = LangSpec {
     block_comment: Some(("/*", "*/")),
     doc_comment: Some("//"),
     scope: ScopeStyle::Braces,
-    signature_patterns: &[
-        r"^\s*(func|type|var|const)\s+",
-    ],
+    signature_patterns: &[r"^\s*(func|type|var|const)\s+"],
     import_patterns: &[r"^\s*import\s+"],
 };
 
@@ -90,10 +86,7 @@ static SHELL: LangSpec = LangSpec {
     block_comment: None,
     doc_comment: None,
     scope: ScopeStyle::None,
-    signature_patterns: &[
-        r"^\s*\w+\s*\(\)\s*\{",
-        r"^\s*function\s+\w+",
-    ],
+    signature_patterns: &[r"^\s*\w+\s*\(\)\s*\{", r"^\s*function\s+\w+"],
     import_patterns: &[r"^\s*(\.|source)\s+"],
 };
 
@@ -126,9 +119,7 @@ static RUBY: LangSpec = LangSpec {
     block_comment: Some(("=begin", "=end")),
     doc_comment: None,
     scope: ScopeStyle::DoEnd,
-    signature_patterns: &[
-        r"^\s*(def|class|module)\s+",
-    ],
+    signature_patterns: &[r"^\s*(def|class|module)\s+"],
     import_patterns: &[r"^\s*require\s+"],
 };
 
@@ -165,19 +156,58 @@ pub fn detect(file_path: &str, _content: &str) -> ContentType {
 
     match ext.as_str() {
         // Code
-        "rs" => ContentType::Code(LangId { name: "rust", spec: &RUST }),
-        "py" | "pyw" | "pyi" => ContentType::Code(LangId { name: "python", spec: &PYTHON }),
-        "go" => ContentType::Code(LangId { name: "go", spec: &GO }),
-        "ex" | "exs" => ContentType::Code(LangId { name: "elixir", spec: &ELIXIR }),
-        "sh" | "bash" | "zsh" | "fish" => ContentType::Code(LangId { name: "shell", spec: &SHELL }),
-        "js" | "jsx" | "mjs" | "cjs" => ContentType::Code(LangId { name: "javascript", spec: &JAVASCRIPT }),
-        "ts" | "tsx" | "mts" | "cts" => ContentType::Code(LangId { name: "typescript", spec: &JAVASCRIPT }),
-        "java" | "kt" | "kts" => ContentType::Code(LangId { name: "java", spec: &JAVA }),
-        "rb" => ContentType::Code(LangId { name: "ruby", spec: &RUBY }),
-        "c" | "h" => ContentType::Code(LangId { name: "c", spec: &C_LANG }),
-        "cpp" | "cc" | "cxx" | "hpp" | "hh" => ContentType::Code(LangId { name: "cpp", spec: &C_LANG }),
-        "swift" => ContentType::Code(LangId { name: "swift", spec: &C_LANG }),
-        "cs" => ContentType::Code(LangId { name: "csharp", spec: &C_LANG }),
+        "rs" => ContentType::Code(LangId {
+            name: "rust",
+            spec: &RUST,
+        }),
+        "py" | "pyw" | "pyi" => ContentType::Code(LangId {
+            name: "python",
+            spec: &PYTHON,
+        }),
+        "go" => ContentType::Code(LangId {
+            name: "go",
+            spec: &GO,
+        }),
+        "ex" | "exs" => ContentType::Code(LangId {
+            name: "elixir",
+            spec: &ELIXIR,
+        }),
+        "sh" | "bash" | "zsh" | "fish" => ContentType::Code(LangId {
+            name: "shell",
+            spec: &SHELL,
+        }),
+        "js" | "jsx" | "mjs" | "cjs" => ContentType::Code(LangId {
+            name: "javascript",
+            spec: &JAVASCRIPT,
+        }),
+        "ts" | "tsx" | "mts" | "cts" => ContentType::Code(LangId {
+            name: "typescript",
+            spec: &JAVASCRIPT,
+        }),
+        "java" | "kt" | "kts" => ContentType::Code(LangId {
+            name: "java",
+            spec: &JAVA,
+        }),
+        "rb" => ContentType::Code(LangId {
+            name: "ruby",
+            spec: &RUBY,
+        }),
+        "c" | "h" => ContentType::Code(LangId {
+            name: "c",
+            spec: &C_LANG,
+        }),
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => ContentType::Code(LangId {
+            name: "cpp",
+            spec: &C_LANG,
+        }),
+        "swift" => ContentType::Code(LangId {
+            name: "swift",
+            spec: &C_LANG,
+        }),
+        "cs" => ContentType::Code(LangId {
+            name: "csharp",
+            spec: &C_LANG,
+        }),
 
         // Markdown
         "md" | "markdown" | "mdx" => ContentType::Markdown,

--- a/crates/lowfat-compress/src/html.rs
+++ b/crates/lowfat-compress/src/html.rs
@@ -14,19 +14,14 @@ static STYLE_BLOCK: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?s)<style[^>]*>.*?</style>").unwrap());
 static SCRIPT_BLOCK: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?s)<script[^>]*>.*?</script>").unwrap());
-static HTML_COMMENT: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
-static INLINE_STYLE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"\s+style="[^"]*""#).unwrap());
+static HTML_COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<!--.*?-->").unwrap());
+static INLINE_STYLE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r#"\s+style="[^"]*""#).unwrap());
 static CLASS_ATTR: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"\s+(class|id|data-[\w-]+)="[^"]*""#).unwrap());
 // Only match real tags (start with letter/!/?), so prose like "a < b and c > d" survives.
-static ALL_TAGS: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"</?[a-zA-Z!?][^>]*>").unwrap());
-static MULTI_SPACE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
-static MULTI_BLANK: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+static ALL_TAGS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"</?[a-zA-Z!?][^>]*>").unwrap());
+static MULTI_SPACE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[ \t]{2,}").unwrap());
+static MULTI_BLANK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
 
 pub fn compress(content: &str, level: Level) -> String {
     match level {
@@ -80,7 +75,8 @@ mod tests {
 
     #[test]
     fn strips_class_attributes() {
-        let input = r#"<div class="container mx-auto" id="main" data-testid="root"><p>Text</p></div>"#;
+        let input =
+            r#"<div class="container mx-auto" id="main" data-testid="root"><p>Text</p></div>"#;
         let result = compress(input, Level::Full);
         assert!(!result.contains("container"));
         assert!(!result.contains("data-testid"));

--- a/crates/lowfat-core/benches/core_bench.rs
+++ b/crates/lowfat-core/benches/core_bench.rs
@@ -112,14 +112,29 @@ fn bench_apply_builtin(c: &mut Criterion) {
     let text = make_ansi_text(200);
 
     let mut group = c.benchmark_group("apply_builtin");
-    for name in &["strip-ansi", "truncate", "head", "token-budget", "dedup-blank", "passthrough"] {
+    for name in &[
+        "strip-ansi",
+        "truncate",
+        "head",
+        "token-budget",
+        "dedup-blank",
+        "passthrough",
+    ] {
         group.bench_function(*name, |b| {
             b.iter(|| apply_builtin(black_box(name), black_box(&text), Level::Full, None, None))
         });
     }
     // Unknown name returns None immediately
     group.bench_function("unknown", |b| {
-        b.iter(|| apply_builtin(black_box("git-compact"), black_box(&text), Level::Full, None, None))
+        b.iter(|| {
+            apply_builtin(
+                black_box("git-compact"),
+                black_box(&text),
+                Level::Full,
+                None,
+                None,
+            )
+        })
     });
     group.finish();
 }

--- a/crates/lowfat-core/src/config.rs
+++ b/crates/lowfat-core/src/config.rs
@@ -1,5 +1,5 @@
 use crate::level::Level;
-use crate::pipeline::{ConditionalPipelines, parse_conditional_pipeline};
+use crate::pipeline::{parse_conditional_pipeline, ConditionalPipelines};
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
@@ -71,9 +71,7 @@ impl RunfConfig {
                             level = l;
                         }
                     } else if let Some(val) = line.strip_prefix("filters=") {
-                        allowed = Some(
-                            val.split(',').map(|s| s.trim().to_string()).collect(),
-                        );
+                        allowed = Some(val.split(',').map(|s| s.trim().to_string()).collect());
                     } else if let Some(val) = line.strip_prefix("disable=") {
                         for name in val.split(',') {
                             disabled.insert(name.trim().to_string());
@@ -311,12 +309,7 @@ mod tests {
 
     #[test]
     fn home_dot_lowfat_used_when_neither_xdg_set_nor_exists() {
-        let r = resolve_home_dir(
-            None,
-            None,
-            std::path::Path::new("/home/user"),
-            &|_| false,
-        );
+        let r = resolve_home_dir(None, None, std::path::Path::new("/home/user"), &|_| false);
         assert_eq!(r, PathBuf::from("/home/user/.lowfat"));
     }
 
@@ -344,12 +337,9 @@ mod tests {
         let xdg_dir = home.join(".config/lowfat");
         // path_is_dir reports only the XDG path as a directory; ~/.lowfat
         // exists on the real fs as a file but is_dir returns false.
-        let r = resolve_home_dir(
-            None,
-            Some("/home/user/.config"),
-            &home,
-            &|p| p == xdg_dir.as_path(),
-        );
+        let r = resolve_home_dir(None, Some("/home/user/.config"), &home, &|p| {
+            p == xdg_dir.as_path()
+        });
         assert_eq!(r, xdg_dir);
     }
 

--- a/crates/lowfat-core/src/db.rs
+++ b/crates/lowfat-core/src/db.rs
@@ -275,11 +275,9 @@ impl Db {
         match filter {
             PruneFilter::All => {
                 if dry_run {
-                    let n: i64 = self.conn.query_row(
-                        "SELECT COUNT(*) FROM invocations",
-                        [],
-                        |r| r.get(0),
-                    )?;
+                    let n: i64 =
+                        self.conn
+                            .query_row("SELECT COUNT(*) FROM invocations", [], |r| r.get(0))?;
                     Ok(n as u64)
                 } else {
                     let n = self.conn.execute("DELETE FROM invocations", [])?;
@@ -548,7 +546,7 @@ mod tests {
         let record = TrackRecord {
             original_cmd: "git status".to_string(),
             lowfat_cmd: "lowfat git status".to_string(),
-            raw: "a".repeat(100), // 25 tokens
+            raw: "a".repeat(100),     // 25 tokens
             filtered: "a".repeat(40), // 10 tokens
             exec_time_ms: 50,
             project_path: "/tmp/test".to_string(),
@@ -579,9 +577,11 @@ mod tests {
                 reduced: true,
                 is_external_plugin: false,
                 exit_code: 0,
-            }).unwrap();
+            })
+            .unwrap();
         }
-        let count: i64 = db.conn
+        let count: i64 = db
+            .conn
             .query_row("SELECT COUNT(*) FROM invocations", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, super::INVOCATIONS_CAP);
@@ -595,22 +595,32 @@ mod tests {
         // "cargo build": 5 × 2000 × 0.05 savings = score 500 (big but barely filtered)
         for _ in 0..5 {
             db.record_invocation(&InvocationRecord {
-                command: "cargo".into(), subcommand: "build".into(),
-                raw_tokens: 2000, filtered_tokens: 1900,
-                had_plugin: false, in_scope: false, reduced: true,
+                command: "cargo".into(),
+                subcommand: "build".into(),
+                raw_tokens: 2000,
+                filtered_tokens: 1900,
+                had_plugin: false,
+                in_scope: false,
+                reduced: true,
                 is_external_plugin: false,
                 exit_code: 0,
-            }).unwrap();
+            })
+            .unwrap();
         }
         // "git status": 10 × 30 × 0.9 savings = score 270 (small and well-filtered)
         for _ in 0..10 {
             db.record_invocation(&InvocationRecord {
-                command: "git".into(), subcommand: "status".into(),
-                raw_tokens: 30, filtered_tokens: 3,
-                had_plugin: true, in_scope: true, reduced: true,
+                command: "git".into(),
+                subcommand: "status".into(),
+                raw_tokens: 30,
+                filtered_tokens: 3,
+                had_plugin: true,
+                in_scope: true,
+                reduced: true,
                 is_external_plugin: false,
                 exit_code: 0,
-            }).unwrap();
+            })
+            .unwrap();
         }
 
         // show_all=true: keep tiny git-status group so we can still assert both rows.
@@ -823,7 +833,8 @@ mod tests {
                 filtered: "a".repeat(20),
                 exec_time_ms: 10,
                 project_path: "/tmp".to_string(),
-            }).unwrap();
+            })
+            .unwrap();
         }
 
         let top = db.top_commands(10).unwrap();

--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -7,8 +7,10 @@
 //! source line numbers.
 
 use crate::level::Level;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 // ──────────────────────────────────────────────────────────────────
 // AST
@@ -204,13 +206,28 @@ const OP_KEYWORDS: &[&str] = &[
     "match",
 ];
 
+/// Parse a `.lf` source string with no filesystem context. `include`
+/// directives are rejected here — they need a base directory to resolve
+/// against, so use [`load`] for file-backed filters. Used by tests and
+/// embedded (in-`.rodata`) filters, which have no on-disk location.
 pub fn parse(input: &str) -> Result<RuleSet> {
     let lines = split_lines(input);
-    let macro_names = collect_macro_names(&lines);
+    parse_lines(&lines, &[], false)
+}
+
+/// Parse pre-split lines. `inherited` are macro names pulled in from
+/// `include`d files (empty for a standalone parse); they're added to the
+/// macro vocabulary so calls to imported macros parse as calls, not ops.
+/// `includes_resolved` tells the parser the loader already handled the
+/// `include` lines — true from [`load`], false from [`parse`].
+fn parse_lines(lines: &[Line], inherited: &[String], includes_resolved: bool) -> Result<RuleSet> {
+    let mut macro_names = collect_macro_names(lines);
+    macro_names.extend(inherited.iter().cloned());
     let mut p = Parser {
-        lines: &lines,
+        lines,
         pos: 0,
         macro_names,
+        includes_resolved,
     };
     p.parse_ruleset()
 }
@@ -234,10 +251,181 @@ fn collect_macro_names(lines: &[Line]) -> Vec<String> {
     names
 }
 
+// ── include resolution ───────────────────────────────────────────
+//
+// `include` is a module layer that sits *around* the parser: the loader
+// reads the graph, merges every file's `define`s, and hands the parser a
+// complete macro vocabulary. Includes never reach the `Op`/`RuleSet` AST —
+// the executor, explain trace and PEP-723 scan stay oblivious.
+
+/// A macro paired with the file that actually `define`d it. The origin lets
+/// us tell a real name collision (two different files) from a diamond import
+/// (the same macro reached by two include paths).
+#[derive(Clone)]
+struct OwnedDefine {
+    def: Define,
+    origin: PathBuf,
+}
+
+/// `include foo.lf` line on the include scan.
+struct IncludeDirective {
+    path: String,
+    line_no: usize,
+}
+
+fn is_include_line(text: &str) -> bool {
+    text == "include" || text.starts_with("include ")
+}
+
+/// Pull `include` paths off the raw lines without a full parse — runs before
+/// op bodies are parsed, since the parser needs imported macro names first.
+fn collect_includes(lines: &[Line]) -> Result<Vec<IncludeDirective>> {
+    let mut out = Vec::new();
+    for l in lines {
+        if l.is_meta || l.indent != 0 || !is_include_line(&l.text) {
+            continue;
+        }
+        let rest = l.text["include".len()..].trim();
+        let path = strip_quotes(rest);
+        if path.is_empty() {
+            bail!("line {}: `include` needs a path", l.line_no);
+        }
+        out.push(IncludeDirective {
+            path: path.to_string(),
+            line_no: l.line_no,
+        });
+    }
+    Ok(out)
+}
+
+/// Strip a single layer of matching `"..."` quotes; otherwise return as-is.
+fn strip_quotes(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2 && b[0] == b'"' && b[b.len() - 1] == b'"' {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Load a `.lf` file and resolve its `include` graph into one [`RuleSet`].
+/// `define`s are merged from every included file; `rules` come from the root
+/// file only (an included file's rules are ignored — it may double as a
+/// runnable filter). Paths resolve relative to the including file.
+pub fn load(path: &Path) -> Result<RuleSet> {
+    let mut loader = Loader::default();
+    let (defs, rules) = loader.load_file(path, true)?;
+    Ok(RuleSet {
+        defines: defs.into_iter().map(|d| d.def).collect(),
+        rules,
+    })
+}
+
+#[derive(Default)]
+struct Loader {
+    /// Canonical path → its exported defines. Caches diamond imports so a
+    /// shared file is read and parsed once.
+    cache: HashMap<PathBuf, Vec<OwnedDefine>>,
+    /// Canonical paths on the current load chain, for cycle detection.
+    loading: Vec<PathBuf>,
+}
+
+impl Loader {
+    /// Returns `(exported defines, rules)`. Rules are empty unless `is_root`.
+    fn load_file(&mut self, path: &Path, is_root: bool) -> Result<(Vec<OwnedDefine>, Vec<Rule>)> {
+        // Canonicalize for cycle/cache keys; fall back to the given path so a
+        // missing file fails later with a clear "reading X" error.
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+        if let Some(cached) = self.cache.get(&canon) {
+            return Ok((cached.clone(), Vec::new()));
+        }
+        if self.loading.contains(&canon) {
+            let chain = self
+                .loading
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(" -> ");
+            bail!("include cycle: {} -> {}", chain, canon.display());
+        }
+        self.loading.push(canon.clone());
+
+        let result = self.load_file_inner(path, &canon, is_root);
+        self.loading.pop();
+
+        let (exported, rules) = result?;
+        self.cache.insert(canon, exported.clone());
+        Ok((exported, rules))
+    }
+
+    fn load_file_inner(
+        &mut self,
+        path: &Path,
+        canon: &Path,
+        is_root: bool,
+    ) -> Result<(Vec<OwnedDefine>, Vec<Rule>)> {
+        let src =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+        let lines = split_lines(&src);
+        let base = path.parent().unwrap_or_else(|| Path::new("."));
+
+        // Resolve includes first to know the full macro vocabulary.
+        let mut inherited: Vec<OwnedDefine> = Vec::new();
+        for inc in collect_includes(&lines)? {
+            let inc_path = base.join(&inc.path);
+            let (defs, _) = self.load_file(&inc_path, false).with_context(|| {
+                format!("{}:{}: include {}", path.display(), inc.line_no, inc.path)
+            })?;
+            for d in defs {
+                merge_inherited(&mut inherited, d)?;
+            }
+        }
+
+        let names: Vec<String> = inherited.iter().map(|d| d.def.name.clone()).collect();
+        let rs = parse_lines(&lines, &names, true)
+            .with_context(|| format!("parsing {}", path.display()))?;
+
+        // Local defines override inherited ones of the same name.
+        let mut exported = inherited;
+        for def in rs.defines {
+            exported.retain(|d| d.def.name != def.name);
+            exported.push(OwnedDefine {
+                def,
+                origin: canon.to_path_buf(),
+            });
+        }
+
+        Ok((exported, if is_root { rs.rules } else { Vec::new() }))
+    }
+}
+
+/// Accumulate an inherited macro. Same name from the *same* origin is a
+/// diamond import → keep one. Same name from a *different* origin is a real
+/// collision the user must resolve.
+fn merge_inherited(acc: &mut Vec<OwnedDefine>, incoming: OwnedDefine) -> Result<()> {
+    if let Some(existing) = acc.iter().find(|d| d.def.name == incoming.def.name) {
+        if existing.origin == incoming.origin {
+            return Ok(()); // same macro, two paths
+        }
+        bail!(
+            "macro `{}` imported from both {} and {}; rename one or override it locally",
+            incoming.def.name,
+            existing.origin.display(),
+            incoming.origin.display()
+        );
+    }
+    acc.push(incoming);
+    Ok(())
+}
+
 struct Parser<'a> {
     lines: &'a [Line],
     pos: usize,
     macro_names: Vec<String>,
+    /// True when an `include` graph was already resolved by [`load`], so the
+    /// structural parser skips `include` lines instead of erroring on them.
+    includes_resolved: bool,
 }
 
 impl<'a> Parser<'a> {
@@ -273,6 +461,16 @@ impl<'a> Parser<'a> {
         while let Some(line) = self.peek_significant() {
             if line.indent != 0 {
                 bail!("line {}: unexpected indent at top level", line.line_no);
+            }
+            if is_include_line(&line.text) {
+                if self.includes_resolved {
+                    self.advance(); // already merged by the loader
+                    continue;
+                }
+                bail!(
+                    "line {}: `include` needs a file to resolve against; load the .lf from disk",
+                    line.line_no
+                );
             }
             if line.text.starts_with("define ") {
                 let d = self.parse_define()?;
@@ -325,8 +523,7 @@ impl<'a> Parser<'a> {
             .ok_or_else(|| anyhow!("line {}: missing `:` in rule header", line_no))?;
         let selector = &header.text[..colon_pos];
         let after = &header.text[colon_pos + 1..];
-        let (sub, level) =
-            parse_selector(selector).with_context(|| format!("line {line_no}"))?;
+        let (sub, level) = parse_selector(selector).with_context(|| format!("line {line_no}"))?;
 
         let mut ops = Vec::new();
         let inline = after.trim();
@@ -461,12 +658,7 @@ impl<'a> Parser<'a> {
     /// Body of one arm — used by `if`/`elif`/`else` and by `match` arms.
     /// Inline ops after `:` force a pipeline body; otherwise the body may
     /// be a nested cascade (`if` or `match`) or a plain indented pipeline.
-    fn parse_arm_body(
-        &mut self,
-        inline: &str,
-        indent: usize,
-        line_no: usize,
-    ) -> Result<Vec<Op>> {
+    fn parse_arm_body(&mut self, inline: &str, indent: usize, line_no: usize) -> Result<Vec<Op>> {
         let mut ops = Vec::new();
         if !inline.is_empty() {
             ops.extend(self.parse_inline_ops(inline, line_no)?);
@@ -612,18 +804,12 @@ impl<'a> Parser<'a> {
             }
             // `raw` is canonical; `passthrough` is a v0.5.0 legacy alias.
             "raw" | "passthrough" => Ok(Op::Raw),
-            "shell:" => Ok(Op::Shell(self.parse_block_body(
-                text,
-                head,
-                indent,
-                line_no,
-            )?)),
-            "python:" => Ok(Op::Python(self.parse_block_body(
-                text,
-                head,
-                indent,
-                line_no,
-            )?)),
+            "shell:" => Ok(Op::Shell(
+                self.parse_block_body(text, head, indent, line_no)?,
+            )),
+            "python:" => Ok(Op::Python(
+                self.parse_block_body(text, head, indent, line_no)?,
+            )),
             "split" => {
                 let rest = text[head.len()..].trim_start();
                 let delim = parse_regex_literal(rest, line_no)?;
@@ -870,10 +1056,7 @@ fn parse_selector(s: &str) -> Result<(SubPattern, LevelPattern)> {
     let sub = if sub_str == "*" {
         SubPattern::Star
     } else {
-        let alts: Vec<String> = sub_str
-            .split('|')
-            .map(|s| s.trim().to_string())
-            .collect();
+        let alts: Vec<String> = sub_str.split('|').map(|s| s.trim().to_string()).collect();
         if alts.iter().any(|a| a.is_empty()) {
             bail!("empty alternative in sub pattern `{}`", sub_str);
         }
@@ -944,11 +1127,17 @@ fn parse_atom(s: &str, line_no: usize) -> Result<Atom> {
         ("exit", Some("ok")) => Ok(Atom::Exit(ExitMatch::Ok)),
         ("exit", Some("failed")) => Ok(Atom::Exit(ExitMatch::Failed)),
         ("exit", Some(v)) => {
-            bail!("line {}: unknown exit value `{}` (expected ok|failed)", line_no, v)
+            bail!(
+                "line {}: unknown exit value `{}` (expected ok|failed)",
+                line_no,
+                v
+            )
         }
         ("exit", None) => bail!("line {}: `exit` guard needs a value (ok|failed)", line_no),
         ("level", Some(v)) => {
-            let lvl: Level = v.parse().map_err(|e: String| anyhow!("line {line_no}: {e}"))?;
+            let lvl: Level = v
+                .parse()
+                .map_err(|e: String| anyhow!("line {line_no}: {e}"))?;
             Ok(Atom::Level(lvl))
         }
         ("level", None) => bail!("line {}: `level` guard needs a value", line_no),
@@ -1043,11 +1232,7 @@ fn parse_regex_literal(s: &str, line_no: usize) -> Result<PatternRegex> {
 fn parse_regex_literal_and_rest(s: &str, line_no: usize) -> Result<(PatternRegex, &str)> {
     let s = s.trim_start();
     if !s.starts_with('/') {
-        bail!(
-            "line {}: expected `/regex/`, got `{}`",
-            line_no,
-            preview(s)
-        );
+        bail!("line {}: expected `/regex/`, got `{}`", line_no, preview(s));
     }
     let body = &s[1..];
     let mut src = String::new();
@@ -1101,11 +1286,7 @@ fn parse_string_literal(s: &str, line_no: usize) -> Result<String> {
 fn parse_string_literal_and_rest(s: &str, line_no: usize) -> Result<(String, &str)> {
     let s = s.trim_start();
     if !s.starts_with('"') {
-        bail!(
-            "line {}: expected `\"...\"`, got `{}`",
-            line_no,
-            preview(s)
-        );
+        bail!("line {}: expected `\"...\"`, got `{}`", line_no, preview(s));
     }
     let body = &s[1..];
     let mut out = String::new();
@@ -1145,13 +1326,9 @@ fn parse_head_arg(s: &str, line_no: usize) -> Result<HeadArg> {
     if s == "auto" {
         return Ok(HeadArg::Auto);
     }
-    s.parse::<usize>().map(HeadArg::Number).map_err(|_| {
-        anyhow!(
-            "line {}: expected number or `auto`, got `{}`",
-            line_no,
-            s
-        )
-    })
+    s.parse::<usize>()
+        .map(HeadArg::Number)
+        .map_err(|_| anyhow!("line {}: expected number or `auto`, got `{}`", line_no, s))
 }
 
 fn parse_macro_args(s: &str, line_no: usize) -> Result<Vec<MacroArg>> {
@@ -1266,11 +1443,7 @@ pub struct ExplainTrace {
 /// recorded — macros and split sub-chains run silently. Adds ~µs of
 /// overhead per op for line/byte counting; safe for interactive use,
 /// avoid in tight loops.
-pub fn execute_explain(
-    rs: &RuleSet,
-    ctx: &ExecCtx,
-    input: &str,
-) -> Result<(String, ExplainTrace)> {
+pub fn execute_explain(rs: &RuleSet, ctx: &ExecCtx, input: &str) -> Result<(String, ExplainTrace)> {
     let mut trace = ExplainTrace::default();
     let Some((idx, rule)) = rs
         .rules
@@ -1475,9 +1648,9 @@ fn atom_matches(a: &Atom, ctx: &ExecCtx) -> bool {
 /// (prune) differently from `-o json` (pass through byte-exact).
 fn flag_matches(spec: &str, args: &[String]) -> bool {
     match spec.split_once(char::is_whitespace) {
-        None => args.iter().any(|a| {
-            a == spec || a.split_once('=').is_some_and(|(name, _)| name == spec)
-        }),
+        None => args
+            .iter()
+            .any(|a| a == spec || a.split_once('=').is_some_and(|(name, _)| name == spec)),
         Some((flag, value)) => {
             let value = value.trim();
             args.windows(2).any(|w| w[0] == flag && w[1] == value)
@@ -1495,10 +1668,7 @@ fn resolve_head(arg: &HeadArg, level: Level) -> usize {
 }
 
 fn filter_lines(s: &str, mut keep: impl FnMut(&str) -> bool) -> String {
-    s.lines()
-        .filter(|l| keep(l))
-        .collect::<Vec<_>>()
-        .join("\n")
+    s.lines().filter(|l| keep(l)).collect::<Vec<_>>().join("\n")
 }
 
 fn take_head(s: &str, n: usize) -> String {
@@ -1987,14 +2157,20 @@ foo:
 
     #[test]
     fn git_compact_plugin_parses() {
-        let src = include_str!(
-            "../../lowfat-plugin/embedded/git/git-compact/filter.lf"
-        );
+        let src = include_str!("../../lowfat-plugin/embedded/git/git-compact/filter.lf");
         let rs = parse_ok(src);
         // Defines: strip-trailers, abbrev-hash, compact-diff, drop-index-meta
         assert_eq!(rs.defines.len(), 4);
         let names: Vec<&str> = rs.defines.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names, ["strip-trailers", "abbrev-hash", "compact-diff", "drop-index-meta"]);
+        assert_eq!(
+            names,
+            [
+                "strip-trailers",
+                "abbrev-hash",
+                "compact-diff",
+                "drop-index-meta"
+            ]
+        );
         assert_eq!(rs.defines[2].params, vec!["limit".to_string()]);
 
         // Selection sanity
@@ -2294,18 +2470,14 @@ foo:
         assert!(has_pep723_header(
             "# /// script\n# dependencies = []\n# ///\nimport sys"
         ));
-        assert!(has_pep723_header(
-            "    # /// script\n    # ///\nimport sys"
-        ));
+        assert!(has_pep723_header("    # /// script\n    # ///\nimport sys"));
         assert!(!has_pep723_header("import sys\nprint('hi')"));
         assert!(!has_pep723_header("# not pep 723\nprint('hi')"));
     }
 
     #[test]
     fn kubectl_compact_plugin_parses() {
-        let src = include_str!(
-            "../../../test-fixtures/plugins/kubectl/kubectl-compact/filter.lf"
-        );
+        let src = include_str!("../../../test-fixtures/plugins/kubectl/kubectl-compact/filter.lf");
         let rs = parse_ok(src);
         // Define: clean-yaml (with PEP 723 body)
         assert_eq!(rs.defines.len(), 1);
@@ -2359,8 +2531,18 @@ diff:
 "#,
         );
         let input = "a\nb\nc\n";
-        let failed = ExecCtx { sub: "diff", level: Level::Full, exit_code: 1, args: &[] };
-        let ok = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &[] };
+        let failed = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 1,
+            args: &[],
+        };
+        let ok = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 0,
+            args: &[],
+        };
         assert_eq!(execute(&rs, &failed, input).unwrap(), "a\nb\nc\n");
         assert_eq!(execute(&rs, &ok, input).unwrap(), "a\n");
     }
@@ -2377,9 +2559,24 @@ diff:
         );
         let input = "1\n2\n3\n4\n";
         let stat = vec!["--stat".to_string()];
-        let ultra_stat = ExecCtx { sub: "diff", level: Level::Ultra, exit_code: 0, args: &stat };
-        let full_stat = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &stat };
-        let plain = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &[] };
+        let ultra_stat = ExecCtx {
+            sub: "diff",
+            level: Level::Ultra,
+            exit_code: 0,
+            args: &stat,
+        };
+        let full_stat = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 0,
+            args: &stat,
+        };
+        let plain = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 0,
+            args: &[],
+        };
         assert_eq!(execute(&rs, &ultra_stat, input).unwrap(), "1\n");
         assert_eq!(execute(&rs, &full_stat, input).unwrap(), "1\n2\n");
         assert_eq!(execute(&rs, &plain, input).unwrap(), "1\n2\n3\n");
@@ -2395,9 +2592,24 @@ diff:
         let split = vec!["--output".to_string(), "json".to_string()];
         let glued = vec!["--output=json".to_string()];
         let none = vec!["pods".to_string()];
-        let split_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &split };
-        let glued_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &glued };
-        let none_ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &none };
+        let split_ctx = ExecCtx {
+            sub: "get",
+            level: Level::Full,
+            exit_code: 0,
+            args: &split,
+        };
+        let glued_ctx = ExecCtx {
+            sub: "get",
+            level: Level::Full,
+            exit_code: 0,
+            args: &glued,
+        };
+        let none_ctx = ExecCtx {
+            sub: "get",
+            level: Level::Full,
+            exit_code: 0,
+            args: &none,
+        };
         assert_eq!(execute(&rs, &split_ctx, input).unwrap(), input);
         assert_eq!(execute(&rs, &glued_ctx, input).unwrap(), input);
         // No output flag → compaction (head 1) still applies.
@@ -2409,7 +2621,12 @@ diff:
         // `--stat` must NOT match `--statistics` — the `=` split guards this.
         let rs = parse_ok("diff:\n    if --stat: head 1\n    else: head 2\n");
         let stats = vec!["--statistics".to_string()];
-        let ctx = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &stats };
+        let ctx = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 0,
+            args: &stats,
+        };
         assert_eq!(execute(&rs, &ctx, "1\n2\n3\n").unwrap(), "1\n2\n");
     }
 
@@ -2427,7 +2644,12 @@ diff:
             (vec!["-o".to_string(), "json".to_string()], input), // else → raw
         ];
         for (args, want) in cases {
-            let ctx = ExecCtx { sub: "get", level: Level::Full, exit_code: 0, args: &args };
+            let ctx = ExecCtx {
+                sub: "get",
+                level: Level::Full,
+                exit_code: 0,
+                args: &args,
+            };
             assert_eq!(execute(&rs, &ctx, input).unwrap(), want, "args={args:?}");
         }
     }
@@ -2461,13 +2683,22 @@ diff:
     fn or_is_alias_of_else() {
         let new = parse_ok("s:\n    keep /Z/\n    or \"clean\"\n");
         let old = parse_ok("s:\n    keep /Z/\n    else \"clean\"\n");
-        assert_eq!(execute(&new, &ctx("s", Level::Full), "nope\n").unwrap(), "clean\n");
-        assert_eq!(execute(&old, &ctx("s", Level::Full), "nope\n").unwrap(), "clean\n");
+        assert_eq!(
+            execute(&new, &ctx("s", Level::Full), "nope\n").unwrap(),
+            "clean\n"
+        );
+        assert_eq!(
+            execute(&old, &ctx("s", Level::Full), "nope\n").unwrap(),
+            "clean\n"
+        );
     }
 
     #[test]
     fn errors_on_unknown_guard_value() {
-        let chain = format!("{:#}", parse("diff:\n    if exit boom: head 1\n").unwrap_err());
+        let chain = format!(
+            "{:#}",
+            parse("diff:\n    if exit boom: head 1\n").unwrap_err()
+        );
         assert!(chain.contains("unknown exit value"), "got: {chain}");
     }
 
@@ -2539,8 +2770,18 @@ diff:
 "#,
         );
         let input = "a\nb\nc\n";
-        let failed = ExecCtx { sub: "diff", level: Level::Full, exit_code: 1, args: &[] };
-        let okctx = ExecCtx { sub: "diff", level: Level::Full, exit_code: 0, args: &[] };
+        let failed = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 1,
+            args: &[],
+        };
+        let okctx = ExecCtx {
+            sub: "diff",
+            level: Level::Full,
+            exit_code: 0,
+            args: &[],
+        };
         assert_eq!(execute(&rs, &failed, input).unwrap(), "a\nb\nc\n");
         assert_eq!(execute(&rs, &okctx, input).unwrap(), "a\n");
     }
@@ -2560,10 +2801,30 @@ plan:
 "#,
         );
         let input = "a\nb\nc\nd\n";
-        let failed = ExecCtx { sub: "plan", level: Level::Full, exit_code: 1, args: &[] };
-        let ok_full = ExecCtx { sub: "plan", level: Level::Full, exit_code: 0, args: &[] };
-        let ok_ultra = ExecCtx { sub: "plan", level: Level::Ultra, exit_code: 0, args: &[] };
-        let ok_lite = ExecCtx { sub: "plan", level: Level::Lite, exit_code: 0, args: &[] };
+        let failed = ExecCtx {
+            sub: "plan",
+            level: Level::Full,
+            exit_code: 1,
+            args: &[],
+        };
+        let ok_full = ExecCtx {
+            sub: "plan",
+            level: Level::Full,
+            exit_code: 0,
+            args: &[],
+        };
+        let ok_ultra = ExecCtx {
+            sub: "plan",
+            level: Level::Ultra,
+            exit_code: 0,
+            args: &[],
+        };
+        let ok_lite = ExecCtx {
+            sub: "plan",
+            level: Level::Lite,
+            exit_code: 0,
+            args: &[],
+        };
         assert_eq!(execute(&rs, &failed, input).unwrap(), input);
         assert_eq!(execute(&rs, &ok_full, input).unwrap(), "a\nb\n");
         assert_eq!(execute(&rs, &ok_ultra, input).unwrap(), "a\n");
@@ -2572,7 +2833,10 @@ plan:
 
     #[test]
     fn match_missing_dimension_errors() {
-        let chain = format!("{:#}", parse("plan:\n    match:\n        ultra: head 1\n").unwrap_err());
+        let chain = format!(
+            "{:#}",
+            parse("plan:\n    match:\n        ultra: head 1\n").unwrap_err()
+        );
         assert!(chain.contains("needs a dimension"), "got: {chain}");
     }
 
@@ -2600,9 +2864,148 @@ plan:
             "{:#}",
             parse("plan:\n    match level: head 1\n").unwrap_err()
         );
-        assert!(
-            chain.contains("doesn't take inline ops"),
-            "got: {chain}"
+        assert!(chain.contains("doesn't take inline ops"), "got: {chain}");
+    }
+
+    // ── include ──────────────────────────────────────────────────
+
+    fn write(dir: &Path, name: &str, body: &str) -> PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn include_merges_defines_and_resolves_calls() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "lib.lf", "define trim:\n    head 5\n");
+        let root = write(d.path(), "main.lf", "include lib.lf\n\n*:\n    trim\n");
+
+        let rs = load(&root).unwrap();
+        assert!(rs.find_define("trim").is_some(), "imported macro present");
+        // `trim` parsed as a macro call, not an unknown op.
+        assert!(matches!(rs.rules[0].ops[0], Op::MacroCall { .. }));
+    }
+
+    #[test]
+    fn include_resolves_relative_to_including_file() {
+        let d = tempfile::tempdir().unwrap();
+        std::fs::create_dir(d.path().join("sub")).unwrap();
+        write(d.path(), "sub/lib.lf", "define trim:\n    head 5\n");
+        // path is relative to main.lf, which lives next to sub/.
+        let root = write(d.path(), "main.lf", "include sub/lib.lf\n*:\n    trim\n");
+
+        assert!(load(&root).unwrap().find_define("trim").is_some());
+    }
+
+    #[test]
+    fn include_is_transitive() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "a.lf", "define ay:\n    head 1\n");
+        write(d.path(), "b.lf", "include a.lf\ndefine bee:\n    head 2\n");
+        let root = write(d.path(), "main.lf", "include b.lf\n*:\n    ay\n    bee\n");
+
+        let rs = load(&root).unwrap();
+        assert!(rs.find_define("ay").is_some());
+        assert!(rs.find_define("bee").is_some());
+    }
+
+    #[test]
+    fn diamond_import_is_not_a_conflict() {
+        // main -> b, c; both -> shared. `shared`'s macro reaches main twice
+        // via the same origin, which must dedup rather than error.
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "shared.lf", "define common:\n    head 1\n");
+        write(d.path(), "b.lf", "include shared.lf\n");
+        write(d.path(), "c.lf", "include shared.lf\n");
+        let root = write(
+            d.path(),
+            "main.lf",
+            "include b.lf\ninclude c.lf\n*:\n    common\n",
         );
+
+        let rs = load(&root).unwrap();
+        assert_eq!(rs.defines.iter().filter(|x| x.name == "common").count(), 1);
+    }
+
+    #[test]
+    fn conflicting_imports_error() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "x.lf", "define dup:\n    head 1\n");
+        write(d.path(), "y.lf", "define dup:\n    head 2\n");
+        let root = write(
+            d.path(),
+            "main.lf",
+            "include x.lf\ninclude y.lf\n*:\n    dup\n",
+        );
+
+        let err = format!("{:#}", load(&root).unwrap_err());
+        assert!(err.contains("imported from both"), "got: {err}");
+    }
+
+    #[test]
+    fn local_define_overrides_inherited() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "lib.lf", "define trim:\n    head 5\n");
+        let root = write(
+            d.path(),
+            "main.lf",
+            "include lib.lf\ndefine trim:\n    head 99\n*:\n    trim\n",
+        );
+
+        let rs = load(&root).unwrap();
+        let def = rs.find_define("trim").unwrap();
+        assert_eq!(def.ops.len(), 1);
+        assert!(matches!(def.ops[0], Op::Head(HeadArg::Number(99))));
+    }
+
+    #[test]
+    fn include_cycle_errors() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "a.lf", "include b.lf\n");
+        let root = write(d.path(), "b.lf", "include a.lf\n");
+
+        let err = format!("{:#}", load(&root).unwrap_err());
+        assert!(err.contains("include cycle"), "got: {err}");
+    }
+
+    #[test]
+    fn included_file_rules_are_ignored() {
+        let d = tempfile::tempdir().unwrap();
+        // lib.lf is a runnable filter too — its rules must not leak in.
+        write(
+            d.path(),
+            "lib.lf",
+            "define trim:\n    head 5\ngit:\n    head 1\n",
+        );
+        let root = write(d.path(), "main.lf", "include lib.lf\n*:\n    trim\n");
+
+        let rs = load(&root).unwrap();
+        assert_eq!(rs.rules.len(), 1, "only the root's rule");
+        assert!(matches!(rs.rules[0].sub, SubPattern::Star));
+    }
+
+    #[test]
+    fn missing_include_errors() {
+        let d = tempfile::tempdir().unwrap();
+        let root = write(d.path(), "main.lf", "include nope.lf\n*:\n    head 1\n");
+        assert!(load(&root).is_err());
+    }
+
+    #[test]
+    fn quoted_include_path() {
+        let d = tempfile::tempdir().unwrap();
+        write(d.path(), "lib.lf", "define trim:\n    head 5\n");
+        let root = write(d.path(), "main.lf", "include \"lib.lf\"\n*:\n    trim\n");
+        assert!(load(&root).unwrap().find_define("trim").is_some());
+    }
+
+    #[test]
+    fn bare_parse_rejects_include() {
+        let err = format!(
+            "{:#}",
+            parse("include lib.lf\n*:\n    head 1\n").unwrap_err()
+        );
+        assert!(err.contains("include"), "got: {err}");
     }
 }

--- a/crates/lowfat-core/src/lf.rs
+++ b/crates/lowfat-core/src/lf.rs
@@ -290,6 +290,15 @@ fn collect_includes(lines: &[Line]) -> Result<Vec<IncludeDirective>> {
         if path.is_empty() {
             bail!("line {}: `include` needs a path", l.line_no);
         }
+        // Paths resolve relative to the including file; an absolute path would
+        // ignore that base and escape the plugin tree, so reject it up front.
+        if Path::new(path).is_absolute() {
+            bail!(
+                "line {}: `include` path must be relative, got `{}`",
+                l.line_no,
+                path
+            );
+        }
         out.push(IncludeDirective {
             path: path.to_string(),
             line_no: l.line_no,
@@ -2998,6 +3007,14 @@ plan:
         write(d.path(), "lib.lf", "define trim:\n    head 5\n");
         let root = write(d.path(), "main.lf", "include \"lib.lf\"\n*:\n    trim\n");
         assert!(load(&root).unwrap().find_define("trim").is_some());
+    }
+
+    #[test]
+    fn absolute_include_path_rejected() {
+        let d = tempfile::tempdir().unwrap();
+        let root = write(d.path(), "main.lf", "include /etc/passwd.lf\n*:\n    head 1\n");
+        let err = format!("{:#}", load(&root).unwrap_err());
+        assert!(err.contains("must be relative"), "got: {err}");
     }
 
     #[test]

--- a/crates/lowfat-core/src/pipeline.rs
+++ b/crates/lowfat-core/src/pipeline.rs
@@ -142,9 +142,7 @@ impl Pipeline {
 ///   pipeline.git.error = strip-ansi | head
 ///   pipeline.git.empty = passthrough
 ///   pipeline.git.large = strip-ansi | git-compact | token-budget
-pub fn parse_conditional_pipeline(
-    lines: &[(String, String)],
-) -> ConditionalPipelines {
+pub fn parse_conditional_pipeline(lines: &[(String, String)]) -> ConditionalPipelines {
     let mut cp = ConditionalPipelines::default();
     for (key, spec) in lines {
         match key.as_str() {
@@ -184,12 +182,24 @@ fn parse_stage_spec(spec: &str) -> ParsedStage {
             let rest = rest.trim();
             // Try numeric first, fall back to string pattern
             if let Ok(n) = rest.parse::<usize>() {
-                ParsedStage { name, param: Some(n), pattern: None }
+                ParsedStage {
+                    name,
+                    param: Some(n),
+                    pattern: None,
+                }
             } else {
-                ParsedStage { name, param: None, pattern: Some(rest.to_string()) }
+                ParsedStage {
+                    name,
+                    param: None,
+                    pattern: Some(rest.to_string()),
+                }
             }
         }
-        None => ParsedStage { name: spec.trim().to_string(), param: None, pattern: None },
+        None => ParsedStage {
+            name: spec.trim().to_string(),
+            param: None,
+            pattern: None,
+        },
     }
 }
 
@@ -197,9 +207,7 @@ fn parse_stage_spec(spec: &str) -> ParsedStage {
 fn resolve_stage_type(name: &str) -> StageType {
     match name {
         "strip-ansi" | "truncate" | "token-budget" | "dedup-blank" | "normalize" | "head"
-        | "passthrough" | "redact-secrets" | "grep" | "grep-v" | "cut" => {
-            StageType::Builtin
-        }
+        | "passthrough" | "redact-secrets" | "grep" | "grep-v" | "cut" => StageType::Builtin,
         _ => StageType::Plugin,
     }
 }
@@ -350,7 +358,11 @@ pub fn proc_cut(text: &str, spec: &str) -> String {
             let s = s.trim();
             if let Some((a, b)) = s.split_once('-') {
                 let start = a.parse::<usize>().ok()?;
-                let end = if b.is_empty() { usize::MAX } else { b.parse::<usize>().ok()? };
+                let end = if b.is_empty() {
+                    usize::MAX
+                } else {
+                    b.parse::<usize>().ok()?
+                };
                 Some((start, end))
             } else {
                 let n = s.parse::<usize>().ok()?;
@@ -374,7 +386,9 @@ pub fn proc_cut(text: &str, spec: &str) -> String {
                 let end = end.min(n);
                 for i in start..=end {
                     if let Some(&field) = parts.get(i.checked_sub(1).unwrap_or(0)) {
-                        if i >= 1 { selected.push(field); }
+                        if i >= 1 {
+                            selected.push(field);
+                        }
                     }
                 }
             }
@@ -387,7 +401,13 @@ pub fn proc_cut(text: &str, spec: &str) -> String {
 /// Apply a built-in processor by name. Returns None if not a built-in.
 /// When `param` is Some, it overrides the level-based default.
 /// When `pattern` is Some, it provides a string param (regex for grep, field spec for cut).
-pub fn apply_builtin(name: &str, text: &str, level: Level, param: Option<usize>, pattern: Option<&str>) -> Option<String> {
+pub fn apply_builtin(
+    name: &str,
+    text: &str,
+    level: Level,
+    param: Option<usize>,
+    pattern: Option<&str>,
+) -> Option<String> {
     match name {
         "strip-ansi" => Some(proc_strip_ansi(text)),
         "truncate" => {
@@ -515,7 +535,10 @@ mod tests {
         let lines = vec![
             ("".to_string(), "strip-ansi | git-compact".to_string()),
             ("error".to_string(), "head".to_string()),
-            ("large".to_string(), "git-compact | token-budget".to_string()),
+            (
+                "large".to_string(),
+                "git-compact | token-budget".to_string(),
+            ),
         ];
         let cp = parse_conditional_pipeline(&lines);
         assert!(cp.default.is_some());
@@ -628,7 +651,10 @@ mod tests {
 
     #[test]
     fn param_overrides_level_default() {
-        let lines = (0..500).map(|i| format!("line{i}")).collect::<Vec<_>>().join("\n");
+        let lines = (0..500)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         // Without param: Full level truncate = 200 lines
         let default_result = apply_builtin("truncate", &lines, Level::Full, None, None).unwrap();
         assert!(default_result.contains("truncated"));
@@ -696,7 +722,12 @@ mod tests {
     #[test]
     fn redact_slack_token() {
         // Build the token at runtime to avoid GitHub push protection flagging it
-        let token = format!("xoxb-{}-{}-{}", "0".repeat(12), "0".repeat(13), "a".repeat(24));
+        let token = format!(
+            "xoxb-{}-{}-{}",
+            "0".repeat(12),
+            "0".repeat(13),
+            "a".repeat(24)
+        );
         let input = format!("SLACK_TOKEN={token}");
         let out = proc_redact_secrets(&input);
         assert!(out.contains("[REDACTED:slack-token]"));
@@ -738,14 +769,16 @@ mod tests {
     #[test]
     fn grep_via_apply_builtin() {
         let input = "  M src/main.rs\n?? temp.txt\n  D old.rs";
-        let result = apply_builtin("grep", input, Level::Full, None, Some("^\\s*[MADRCU?!]")).unwrap();
+        let result =
+            apply_builtin("grep", input, Level::Full, None, Some("^\\s*[MADRCU?!]")).unwrap();
         assert_eq!(result, "  M src/main.rs\n?? temp.txt\n  D old.rs");
     }
 
     #[test]
     fn grep_v_via_apply_builtin() {
         let input = "index abc123..def456\nmode 100644\n+++ b/file.rs\n--- a/file.rs";
-        let result = apply_builtin("grep-v", input, Level::Full, None, Some("^(index |mode )")).unwrap();
+        let result =
+            apply_builtin("grep-v", input, Level::Full, None, Some("^(index |mode )")).unwrap();
         assert_eq!(result, "+++ b/file.rs\n--- a/file.rs");
     }
 

--- a/crates/lowfat-core/src/redact.rs
+++ b/crates/lowfat-core/src/redact.rs
@@ -11,7 +11,7 @@
 //! Rust; only the *patterns* are data, because compliance needs differ
 //! per organisation (PCI, HIPAA, internal token formats).
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, OnceLock};
@@ -58,7 +58,10 @@ fn defaults() -> &'static [(&'static str, &'static str)] {
             r#"(?i)(api[_-]?key|api[_-]?secret|api[_-]?token|access[_-]?token|secret[_-]?key|auth[_-]?token|private[_-]?key)\s*[=:]\s*['"]?([A-Za-z0-9/+=\-_.]{16,})['"]?"#,
             "$1=[REDACTED]",
         ),
-        (r"(?i)(Bearer\s+)[A-Za-z0-9\-_.~+/]+=*", "${1}[REDACTED:bearer]"),
+        (
+            r"(?i)(Bearer\s+)[A-Za-z0-9\-_.~+/]+=*",
+            "${1}[REDACTED:bearer]",
+        ),
         (
             r"eyJ[A-Za-z0-9\-_]+\.eyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_.+/=]+",
             "[REDACTED:jwt]",
@@ -91,8 +94,8 @@ impl RedactRules {
     /// `<regex> => <replacement>`. A bare `!no-defaults` line drops the
     /// built-in baseline. Returns the rules and the no-defaults flag.
     fn parse_file(path: &Path) -> Result<(Vec<RedactRule>, bool)> {
-        let text = std::fs::read_to_string(path)
-            .with_context(|| format!("reading {}", path.display()))?;
+        let text =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         let mut rules = Vec::new();
         let mut no_defaults = false;
         for (i, raw) in text.lines().enumerate() {
@@ -221,7 +224,11 @@ mod tests {
     #[test]
     fn parse_basic_rule() {
         let dir = tempfile::tempdir().unwrap();
-        let f = write(dir.path(), "redact.conf", "# a comment\nFOO-[0-9]+ => [X]\n");
+        let f = write(
+            dir.path(),
+            "redact.conf",
+            "# a comment\nFOO-[0-9]+ => [X]\n",
+        );
         let (rules, nd) = RedactRules::parse_file(&f).unwrap();
         assert_eq!(rules.len(), 1);
         assert!(!nd);
@@ -255,10 +262,17 @@ mod tests {
     #[test]
     fn no_defaults_directive() {
         let dir = tempfile::tempdir().unwrap();
-        let g = write(dir.path(), "g.conf", "!no-defaults\nEMP-[0-9]{3} => [EMP]\n");
+        let g = write(
+            dir.path(),
+            "g.conf",
+            "!no-defaults\nEMP-[0-9]{3} => [EMP]\n",
+        );
         let rs = RedactRules::load(Some(&g), None).unwrap();
         let out = rs.apply("AKIA0000000000000000 EMP-123");
-        assert!(out.contains("AKIA0000000000000000"), "default dropped: {out}");
+        assert!(
+            out.contains("AKIA0000000000000000"),
+            "default dropped: {out}"
+        );
         assert!(out.contains("[EMP]"));
     }
 

--- a/crates/lowfat-core/src/structured.rs
+++ b/crates/lowfat-core/src/structured.rs
@@ -67,7 +67,11 @@ fn prune(v: &Value, level: Level) -> Value {
     let (max_items, max_str) = caps(level);
     match v {
         Value::Array(items) => {
-            let mut out: Vec<Value> = items.iter().take(max_items).map(|x| prune(x, level)).collect();
+            let mut out: Vec<Value> = items
+                .iter()
+                .take(max_items)
+                .map(|x| prune(x, level))
+                .collect();
             if items.len() > max_items {
                 out.push(Value::String(format!(
                     "... {} more items (lowfat; LOWFAT_LEVEL=lite for more)",
@@ -76,9 +80,11 @@ fn prune(v: &Value, level: Level) -> Value {
             }
             Value::Array(out)
         }
-        Value::Object(map) => {
-            Value::Object(map.iter().map(|(k, x)| (k.clone(), prune(x, level))).collect())
-        }
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(k, x)| (k.clone(), prune(x, level)))
+                .collect(),
+        ),
         Value::String(s) => {
             let n = s.chars().count();
             if n > max_str {
@@ -111,7 +117,10 @@ fn recompact(shape: &Shape, level: Level) -> Option<String> {
             lines.join("\n")
         }
         Shape::WithTrailer(v, trailer) => {
-            format!("{}\n{trailer}", serde_json::to_string(&prune(v, level)).ok()?)
+            format!(
+                "{}\n{trailer}",
+                serde_json::to_string(&prune(v, level)).ok()?
+            )
         }
     };
     Some(out)
@@ -143,7 +152,10 @@ mod tests {
     }
 
     fn ndjson(n: usize) -> String {
-        (0..n).map(|i| format!("{{\"id\":{i}}}")).collect::<Vec<_>>().join("\n")
+        (0..n)
+            .map(|i| format!("{{\"id\":{i}}}"))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     #[test]

--- a/crates/lowfat-core/src/tee.rs
+++ b/crates/lowfat-core/src/tee.rs
@@ -30,9 +30,7 @@ pub fn save_on_failure(tee_dir: &Path, label: &str, raw: &str, exit_code: i32) {
             .filter(|e| e.path().is_file())
             .collect();
         if files.len() > 20 {
-            files.sort_by_key(|e| {
-                e.metadata().ok().and_then(|m| m.modified().ok())
-            });
+            files.sort_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()));
             for entry in &files[..files.len() - 20] {
                 let _ = fs::remove_file(entry.path());
             }

--- a/crates/lowfat-plugin/src/discovery.rs
+++ b/crates/lowfat-plugin/src/discovery.rs
@@ -20,9 +20,7 @@ impl PluginSource {
     pub fn display_path(&self, category: &str, name: &str) -> PathBuf {
         match self {
             PluginSource::Disk { base_dir } => base_dir.clone(),
-            PluginSource::Embedded { .. } => {
-                PathBuf::from(format!("<embedded>/{category}/{name}"))
-            }
+            PluginSource::Embedded { .. } => PathBuf::from(format!("<embedded>/{category}/{name}")),
         }
     }
 
@@ -43,7 +41,8 @@ impl DiscoveredPlugin {
     /// Path to the plugin's root directory (for disk-backed plugins) or a
     /// synthetic `<embedded>/...` placeholder. Use for display only.
     pub fn base_dir(&self) -> PathBuf {
-        self.source.display_path(&self.category, &self.manifest.plugin.name)
+        self.source
+            .display_path(&self.category, &self.manifest.plugin.name)
     }
 
     pub fn is_embedded(&self) -> bool {
@@ -110,10 +109,7 @@ fn scan_plugin_dir(dir: &Path, plugins: &mut Vec<DiscoveredPlugin>) {
         if !category_path.is_dir() {
             continue;
         }
-        let category = category_entry
-            .file_name()
-            .to_string_lossy()
-            .to_string();
+        let category = category_entry.file_name().to_string_lossy().to_string();
 
         let plugin_entries = match fs::read_dir(&category_path) {
             Ok(e) => e,
@@ -152,7 +148,9 @@ fn scan_plugin_dir(dir: &Path, plugins: &mut Vec<DiscoveredPlugin>) {
             plugins.push(DiscoveredPlugin {
                 manifest,
                 category: category.clone(),
-                source: PluginSource::Disk { base_dir: plugin_path },
+                source: PluginSource::Disk {
+                    base_dir: plugin_path,
+                },
             });
             break;
         }
@@ -183,7 +181,11 @@ mod tests {
         // A nonexistent dir yields only the embedded set (no disk plugins).
         let found = discover_plugins(Path::new("/nonexistent-lowfat-test-dir"));
         let embedded: Vec<_> = found.iter().filter(|p| p.is_embedded()).collect();
-        assert_eq!(embedded.len(), EMBEDDED.len(), "all embedded plugins discovered");
+        assert_eq!(
+            embedded.len(),
+            EMBEDDED.len(),
+            "all embedded plugins discovered"
+        );
 
         for p in &embedded {
             if let PluginSource::Embedded { filter_lf } = &p.source {

--- a/crates/lowfat-plugin/src/manifest.rs
+++ b/crates/lowfat-plugin/src/manifest.rs
@@ -113,8 +113,7 @@ commands = ["git"]
 
     #[test]
     fn resolve_entry_auto_detects() {
-        let dir = std::env::temp_dir()
-            .join(format!("lowfat-resolve-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("lowfat-resolve-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
 

--- a/crates/lowfat-plugin/src/security.rs
+++ b/crates/lowfat-plugin/src/security.rs
@@ -78,9 +78,21 @@ fn validate_hooks(manifest: &PluginManifest) -> Result<(), SecurityError> {
     ];
 
     let hooks = [
-        ("on_install", manifest.hooks.as_ref().and_then(|h| h.on_install.as_deref())),
-        ("on_update", manifest.hooks.as_ref().and_then(|h| h.on_update.as_deref())),
-        ("on_remove", manifest.hooks.as_ref().and_then(|h| h.on_remove.as_deref())),
+        (
+            "on_install",
+            manifest
+                .hooks
+                .as_ref()
+                .and_then(|h| h.on_install.as_deref()),
+        ),
+        (
+            "on_update",
+            manifest.hooks.as_ref().and_then(|h| h.on_update.as_deref()),
+        ),
+        (
+            "on_remove",
+            manifest.hooks.as_ref().and_then(|h| h.on_remove.as_deref()),
+        ),
     ];
 
     for (hook_name, hook_cmd) in &hooks {
@@ -147,11 +159,31 @@ pub fn untrust_plugin(plugin_name: &str, lowfat_home: &Path) -> anyhow::Result<(
 // --- Environment sanitization ---
 
 const SAFE_ENV_VARS: &[&str] = &[
-    "LOWFAT_LEVEL", "LOWFAT_COMMAND", "LOWFAT_SUBCOMMAND", "LOWFAT_EXIT_CODE",
-    "PATH", "HOME", "USER", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "TMPDIR",
-    "GIT_DIR", "GIT_WORK_TREE", "DOCKER_HOST", "KUBECONFIG",
-    "GOPATH", "GOROOT", "CARGO_HOME", "RUSTUP_HOME",
-    "NODE_PATH", "NPM_CONFIG_PREFIX", "VIRTUAL_ENV", "PYTHONPATH",
+    "LOWFAT_LEVEL",
+    "LOWFAT_COMMAND",
+    "LOWFAT_SUBCOMMAND",
+    "LOWFAT_EXIT_CODE",
+    "PATH",
+    "HOME",
+    "USER",
+    "SHELL",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "TMPDIR",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "DOCKER_HOST",
+    "KUBECONFIG",
+    "GOPATH",
+    "GOROOT",
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+    "NODE_PATH",
+    "NPM_CONFIG_PREFIX",
+    "VIRTUAL_ENV",
+    "PYTHONPATH",
 ];
 
 pub fn sanitized_env() -> Vec<(String, String)> {

--- a/crates/lowfat-runner/src/lf_filter.rs
+++ b/crates/lowfat-runner/src/lf_filter.rs
@@ -14,10 +14,8 @@ pub struct LfFilter {
 
 impl LfFilter {
     pub fn load(info: PluginInfo, entry: PathBuf) -> Result<Self> {
-        let source = std::fs::read_to_string(&entry)
-            .with_context(|| format!("reading {}", entry.display()))?;
-        let ruleset =
-            lf::parse(&source).with_context(|| format!("parsing {}", entry.display()))?;
+        // `lf::load` resolves any `include` directives relative to `entry`.
+        let ruleset = lf::load(&entry).with_context(|| format!("parsing {}", entry.display()))?;
         Ok(Self {
             info,
             ruleset,
@@ -29,8 +27,7 @@ impl LfFilter {
     /// the source string lives in `.rodata` and never touches disk. `entry`
     /// is a synthetic display-only path for error messages.
     pub fn from_source(info: PluginInfo, source: &str, entry: PathBuf) -> Result<Self> {
-        let ruleset =
-            lf::parse(source).with_context(|| format!("parsing {}", entry.display()))?;
+        let ruleset = lf::parse(source).with_context(|| format!("parsing {}", entry.display()))?;
         Ok(Self {
             info,
             ruleset,
@@ -88,10 +85,8 @@ mod tests {
     }
 
     fn write_lf(name: &str, body: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!(
-            "lowfat-lf-test-{name}-{}",
-            std::process::id()
-        ));
+        let dir =
+            std::env::temp_dir().join(format!("lowfat-lf-test-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join("filter.lf");

--- a/crates/lowfat-runner/src/process.rs
+++ b/crates/lowfat-runner/src/process.rs
@@ -82,7 +82,8 @@ mod tests {
     }
 
     fn make_filter(entry: &str, code: &str) -> ProcessFilter {
-        let dir = std::env::temp_dir().join(format!("lowfat-test-{}-{}", entry, std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("lowfat-test-{}-{}", entry, std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join(entry);
         let mut f = std::fs::File::create(&path).unwrap();

--- a/crates/lowfat-runner/src/runner.rs
+++ b/crates/lowfat-runner/src/runner.rs
@@ -29,11 +29,7 @@ impl HybridRunner {
                 .clone()
                 .unwrap_or_else(|| "0.0.0".to_string()),
             commands: manifest.plugin.commands.clone(),
-            subcommands: manifest
-                .plugin
-                .subcommands
-                .clone()
-                .unwrap_or_default(),
+            subcommands: manifest.plugin.subcommands.clone().unwrap_or_default(),
         };
 
         match &plugin.source {
@@ -49,10 +45,7 @@ impl HybridRunner {
                     anyhow::bail!("security check failed for '{}': {e}", manifest.plugin.name);
                 }
 
-                let is_lf = entry_path
-                    .extension()
-                    .map(|e| e == "lf")
-                    .unwrap_or(false);
+                let is_lf = entry_path.extension().map(|e| e == "lf").unwrap_or(false);
                 if is_lf {
                     let filter = LfFilter::load(info, entry_path)?;
                     Ok(Box::new(filter))
@@ -100,7 +93,13 @@ pub fn execute_pipeline(
 
         // Fall back to built-in processor
         if stage.stage_type == StageType::Builtin {
-            if let Some(processed) = apply_builtin(&stage.name, &text, input_template.level, stage.param, stage.pattern.as_deref()) {
+            if let Some(processed) = apply_builtin(
+                &stage.name,
+                &text,
+                input_template.level,
+                stage.param,
+                stage.pattern.as_deref(),
+            ) {
                 text = processed;
             }
         }
@@ -120,9 +119,7 @@ pub fn execute_pipeline(
 
 /// Execute a command and capture its output.
 pub fn exec_command(cmd: &str, args: &[String]) -> Result<(String, i32)> {
-    let output = std::process::Command::new(cmd)
-        .args(args)
-        .output()?;
+    let output = std::process::Command::new(cmd).args(args).output()?;
 
     let exit_code = output.status.code().unwrap_or(1);
     let mut combined = String::from_utf8_lossy(&output.stdout).to_string();
@@ -161,7 +158,7 @@ mod tests {
         let raw = "\x1b[31mERROR\x1b[0m\n\n\n\nline2";
         let input = make_input(raw);
         let result = execute_pipeline(&pipeline, raw, &input, &HashMap::new()).unwrap();
-        assert_eq!(result, "ERROR\n\nline2\n");  // normalize collapses blanks + trims
+        assert_eq!(result, "ERROR\n\nline2\n"); // normalize collapses blanks + trims
     }
 
     #[test]
@@ -170,13 +167,16 @@ mod tests {
         let raw = "hello world";
         let input = make_input(raw);
         let result = execute_pipeline(&pipeline, raw, &input, &HashMap::new()).unwrap();
-        assert_eq!(result, "hello world\n");  // normalize ensures trailing newline
+        assert_eq!(result, "hello world\n"); // normalize ensures trailing newline
     }
 
     #[test]
     fn execute_truncate_pipeline() {
         let pipeline = Pipeline::parse("head");
-        let raw = (0..100).map(|i| format!("line{i}")).collect::<Vec<_>>().join("\n");
+        let raw = (0..100)
+            .map(|i| format!("line{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
         let input = make_input(&raw);
         let result = execute_pipeline(&pipeline, &raw, &input, &HashMap::new()).unwrap();
         // Full level head limit for base 40 = 40 lines
@@ -207,7 +207,10 @@ mod tests {
         let pipeline = Pipeline::parse("head");
         let input = make_input(&raw);
         let result = execute_pipeline(&pipeline, &raw, &input, &HashMap::new()).unwrap();
-        assert!(serde_json::from_str::<serde_json::Value>(&result).is_ok(), "broken JSON: {result}");
+        assert!(
+            serde_json::from_str::<serde_json::Value>(&result).is_ok(),
+            "broken JSON: {result}"
+        );
         assert!(result.contains("more items"));
     }
 

--- a/crates/lowfat-runner/tests/e2e_plugin.rs
+++ b/crates/lowfat-runner/tests/e2e_plugin.rs
@@ -15,10 +15,7 @@ use std::path::PathBuf;
 // ---------------------------------------------------------------------------
 
 fn temp_plugin(name: &str, script: &str) -> (ProcessFilter, PathBuf) {
-    let dir = std::env::temp_dir().join(format!(
-        "lowfat-e2e-{name}-{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("lowfat-e2e-{name}-{}", std::process::id()));
     std::fs::create_dir_all(&dir).unwrap();
     let path = dir.join("filter.sh");
     let mut f = std::fs::File::create(&path).unwrap();
@@ -185,11 +182,20 @@ fn kubectl_get_pods_ultra_filters_running() {
     // Header should be present
     assert!(result.text.contains("NAME"), "header missing");
     // Non-Running pods should be present
-    assert!(result.text.contains("CrashLoopBackOff"), "CrashLoop pod missing");
+    assert!(
+        result.text.contains("CrashLoopBackOff"),
+        "CrashLoop pod missing"
+    );
     assert!(result.text.contains("Pending"), "Pending pod missing");
     // Running pods should be filtered out
-    assert!(!result.text.contains("nginx-abc123"), "Running pod should be filtered");
-    assert!(!result.text.contains("redis-def456"), "Running pod should be filtered");
+    assert!(
+        !result.text.contains("nginx-abc123"),
+        "Running pod should be filtered"
+    );
+    assert!(
+        !result.text.contains("redis-def456"),
+        "Running pod should be filtered"
+    );
 }
 
 #[test]
@@ -206,8 +212,14 @@ fn kubectl_get_pods_full_keeps_all() {
     let result = filter.filter(&input).unwrap();
 
     // Full level keeps everything
-    assert!(result.text.contains("nginx-abc123"), "all pods should be present at full");
-    assert!(result.text.contains("CrashLoopBackOff"), "all pods should be present at full");
+    assert!(
+        result.text.contains("nginx-abc123"),
+        "all pods should be present at full"
+    );
+    assert!(
+        result.text.contains("CrashLoopBackOff"),
+        "all pods should be present at full"
+    );
 }
 
 #[test]
@@ -228,8 +240,14 @@ fn kubectl_get_events_ultra_warnings_only() {
     assert!(result.text.contains("BackOff"), "Warning event missing");
     assert!(result.text.contains("Failed"), "Warning event missing");
     // Normal events should be filtered
-    assert!(!result.text.contains("Scheduled"), "Normal event should be filtered");
-    assert!(!result.text.contains("Pulled"), "Normal event should be filtered");
+    assert!(
+        !result.text.contains("Scheduled"),
+        "Normal event should be filtered"
+    );
+    assert!(
+        !result.text.contains("Pulled"),
+        "Normal event should be filtered"
+    );
 }
 
 #[test]
@@ -289,9 +307,18 @@ fn kubectl_get_pods_with_namespace_flag() {
     let result = filter.filter(&input).unwrap();
 
     // Should correctly parse "pods" as resource despite -n flag
-    assert!(result.text.contains("NAME"), "header missing — resource type not parsed correctly");
-    assert!(result.text.contains("CrashLoopBackOff"), "should use pods-specific filter");
-    assert!(!result.text.contains("nginx-abc123"), "Running pods should be filtered in ultra");
+    assert!(
+        result.text.contains("NAME"),
+        "header missing — resource type not parsed correctly"
+    );
+    assert!(
+        result.text.contains("CrashLoopBackOff"),
+        "should use pods-specific filter"
+    );
+    assert!(
+        !result.text.contains("nginx-abc123"),
+        "Running pods should be filtered in ultra"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -379,9 +406,18 @@ fn cargo_build_ultra_shows_warnings_only() {
     );
     let result = filter.filter(&input).unwrap();
 
-    assert!(result.text.contains("warning: unused variable"), "warning line missing");
-    assert!(!result.text.contains("Compiling serde"), "Compiling noise should be stripped");
-    assert!(!result.text.contains("Finished"), "Finished line should be stripped");
+    assert!(
+        result.text.contains("warning: unused variable"),
+        "warning line missing"
+    );
+    assert!(
+        !result.text.contains("Compiling serde"),
+        "Compiling noise should be stripped"
+    );
+    assert!(
+        !result.text.contains("Finished"),
+        "Finished line should be stripped"
+    );
 }
 
 #[test]
@@ -390,7 +426,14 @@ fn cargo_build_ultra_clean_shows_ok() {
    Compiling myapp v0.1.0
     Finished `dev` profile in 2.0s";
     let (filter, _dir) = temp_plugin("cargo-clean", CARGO_SCRIPT);
-    let input = make_input(clean_output, "cargo", "build", vec!["build"], Level::Ultra, 0);
+    let input = make_input(
+        clean_output,
+        "cargo",
+        "build",
+        vec!["build"],
+        Level::Ultra,
+        0,
+    );
     let result = filter.filter(&input).unwrap();
 
     assert!(
@@ -413,9 +456,18 @@ fn cargo_build_full_strips_compiling_noise() {
     );
     let result = filter.filter(&input).unwrap();
 
-    assert!(!result.text.contains("Compiling serde"), "Compiling noise should be stripped");
-    assert!(result.text.contains("warning: unused variable"), "warnings should remain");
-    assert!(result.text.contains("Finished"), "Finished line should remain");
+    assert!(
+        !result.text.contains("Compiling serde"),
+        "Compiling noise should be stripped"
+    );
+    assert!(
+        result.text.contains("warning: unused variable"),
+        "warnings should remain"
+    );
+    assert!(
+        result.text.contains("Finished"),
+        "Finished line should remain"
+    );
 }
 
 #[test]
@@ -431,10 +483,19 @@ fn cargo_test_ultra_shows_failures_only() {
     );
     let result = filter.filter(&input).unwrap();
 
-    assert!(result.text.contains("test result: FAILED"), "result summary missing");
-    assert!(result.text.contains("overflow_check"), "failed test name missing");
+    assert!(
+        result.text.contains("test result: FAILED"),
+        "result summary missing"
+    );
+    assert!(
+        result.text.contains("overflow_check"),
+        "failed test name missing"
+    );
     // Individual ok tests should not appear
-    assert!(!result.text.contains("basic_add"), "passing tests should be stripped");
+    assert!(
+        !result.text.contains("basic_add"),
+        "passing tests should be stripped"
+    );
 }
 
 #[test]
@@ -451,10 +512,16 @@ fn cargo_test_full_strips_ok_tests() {
     let result = filter.filter(&input).unwrap();
 
     // Compiling noise stripped
-    assert!(!result.text.contains("Compiling myapp"), "Compiling should be stripped");
+    assert!(
+        !result.text.contains("Compiling myapp"),
+        "Compiling should be stripped"
+    );
     // Failures and result should remain
     assert!(result.text.contains("FAILED"), "FAILED should remain");
-    assert!(result.text.contains("test result:"), "result summary should remain");
+    assert!(
+        result.text.contains("test result:"),
+        "result summary should remain"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -482,7 +549,11 @@ fn pipeline_with_shell_plugin_and_builtins() {
     let result = execute_pipeline(&pipeline, raw, &input, &plugin_map).unwrap();
 
     // strip-ansi removes ANSI, then upper-compact uppercases
-    assert!(result.contains("HELLO WORLD"), "should be uppercased: {}", result);
+    assert!(
+        result.contains("HELLO WORLD"),
+        "should be uppercased: {}",
+        result
+    );
     assert!(!result.contains("\x1b["), "ANSI should be stripped");
 }
 
@@ -535,13 +606,22 @@ fi
     // Success case
     let input = make_input("all good", "test", "", vec![], Level::Full, 0);
     let result = filter.filter(&input).unwrap();
-    assert!(!result.text.contains("ERROR"), "should not show error on exit 0");
+    assert!(
+        !result.text.contains("ERROR"),
+        "should not show error on exit 0"
+    );
 
     // Failure case
     let input = make_input("something broke", "test", "", vec![], Level::Full, 1);
     let result = filter.filter(&input).unwrap();
-    assert!(result.text.contains("ERROR (exit 1)"), "should show error on exit 1");
-    assert!(result.text.contains("something broke"), "should preserve raw on error");
+    assert!(
+        result.text.contains("ERROR (exit 1)"),
+        "should show error on exit 1"
+    );
+    assert!(
+        result.text.contains("something broke"),
+        "should preserve raw on error"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/lowfat-runner/tests/lf_plugins.rs
+++ b/crates/lowfat-runner/tests/lf_plugins.rs
@@ -244,3 +244,36 @@ fn npm_compact_parity() {
 fn go_compact_parity() {
     check_plugin(&fixtures_dir().join("go/go-compact"), 10.0);
 }
+
+/// End-to-end proof for `include`: the `examples/include` wrapper imports a
+/// macro from another file and that macro actually runs on real input. Uses
+/// `lf::load` (the include-aware entry point), so a regression here means
+/// the example in the docs stopped working.
+#[test]
+fn include_example_resolves_and_runs() {
+    let dir = repo_root().join("examples/include");
+    let rs = lf::load(&dir.join("uv-pytest.lf")).expect("load wrapper with include");
+
+    // The imported macro is in scope despite living in lib/pytest.lf.
+    assert!(rs.find_define("compact-pytest").is_some());
+
+    let raw = std::fs::read_to_string(dir.join("sample-pytest.txt")).unwrap();
+    let args: Vec<String> = vec![];
+    let ctx = ExecCtx {
+        sub: "run", // `uv run pytest`
+        level: Level::Full,
+        exit_code: 0,
+        args: &args,
+    };
+    let out = lf::execute(&rs, &ctx, &raw).expect("execute wrapper");
+
+    // Verdicts + summary kept by the imported macro...
+    assert!(out.contains("test_a PASSED"), "kept verdicts:\n{out}");
+    assert!(out.contains("2 passed, 1 failed"), "kept summary:\n{out}");
+    // ...noise dropped, so it's genuinely compacted.
+    assert!(!out.contains("platform linux"), "dropped noise:\n{out}");
+    assert!(
+        out.lines().count() < raw.lines().count(),
+        "output not compacted"
+    );
+}

--- a/crates/lowfat-runner/tests/lf_plugins.rs
+++ b/crates/lowfat-runner/tests/lf_plugins.rs
@@ -15,12 +15,7 @@ use std::process::{Command, Stdio};
 
 fn repo_root() -> PathBuf {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    manifest
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .to_path_buf()
+    manifest.parent().unwrap().parent().unwrap().to_path_buf()
 }
 
 /// Run the .sh filter with env vars set the way the real lowfat runner
@@ -90,12 +85,7 @@ fn check_plugin(plugin_dir: &Path, tolerance_pct: f64) {
     let entries: Vec<_> = std::fs::read_dir(&samples)
         .unwrap()
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map(|x| x == "txt")
-                .unwrap_or(false)
-        })
+        .filter(|e| e.path().extension().map(|x| x == "txt").unwrap_or(false))
         .collect();
     assert!(!entries.is_empty(), "no samples in {}", samples.display());
 
@@ -197,7 +187,10 @@ fn git_diff_truncation_marker_and_lite_uncapped() {
     );
 
     let lite = run_lf(&plugin.join("filter.lf"), &sample, "diff", Level::Lite);
-    assert!(!lite.contains("git-compact: truncated"), "lite must not cap");
+    assert!(
+        !lite.contains("git-compact: truncated"),
+        "lite must not cap"
+    );
 
     // every hunk header and changed line survives (--- / +++ are meta)
     let hunks = |s: &str| s.lines().filter(|l| l.starts_with("@@ ")).count();
@@ -217,7 +210,13 @@ fn git_diff_truncation_marker_and_lite_uncapped() {
     assert!(!lite.contains("\n--- a/"), "--- meta should be dropped");
 
     // sh baseline must agree
-    let sh_lite = run_sh(&plugin.join("filter.sh"), &sample, "git", "diff", Level::Lite);
+    let sh_lite = run_sh(
+        &plugin.join("filter.sh"),
+        &sample,
+        "git",
+        "diff",
+        Level::Lite,
+    );
     assert_eq!(sh_lite.lines().count(), lite.lines().count());
 }
 

--- a/crates/lowfat/src/commands/config.rs
+++ b/crates/lowfat/src/commands/config.rs
@@ -26,14 +26,28 @@ pub fn run() -> Result<()> {
     } else {
         let mut disabled: Vec<_> = config.disabled.iter().collect();
         disabled.sort();
-        println!("  {D}disable:{R} {}", disabled.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "));
+        println!(
+            "  {D}disable:{R} {}",
+            disabled
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
     }
 
     // Whitelist
     if let Some(ref allowed) = config.allowed {
         let mut filters: Vec<_> = allowed.iter().collect();
         filters.sort();
-        println!("  {D}filters:{R} {}", filters.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", "));
+        println!(
+            "  {D}filters:{R} {}",
+            filters
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
     }
 
     // Pipelines
@@ -78,7 +92,11 @@ pub fn run() -> Result<()> {
                 // Validate level value
                 if let Some(val) = line.strip_prefix("level=") {
                     if !matches!(val, "lite" | "full" | "ultra") {
-                        warnings.push(format!("line {}: invalid level '{}' (expected: lite, full, ultra)", i + 1, val));
+                        warnings.push(format!(
+                            "line {}: invalid level '{}' (expected: lite, full, ultra)",
+                            i + 1,
+                            val
+                        ));
                     }
                 }
                 // Validate pipeline has = and a spec
@@ -90,11 +108,33 @@ pub fn run() -> Result<()> {
                             warnings.push(format!("line {}: pipeline missing command name", i + 1));
                         }
                         if spec.is_empty() {
-                            warnings.push(format!("line {}: pipeline.{} has empty spec", i + 1, key));
+                            warnings.push(format!(
+                                "line {}: pipeline.{} has empty spec",
+                                i + 1,
+                                key
+                            ));
                         }
                         // Check condition suffix
                         if let Some((_, cond)) = key.split_once('.') {
-                            if !matches!(cond, "error" | "empty" | "large" | "diff" | "status" | "log" | "show" | "build" | "test" | "check" | "clippy" | "run" | "install" | "audit" | "ps" | "images") {
+                            if !matches!(
+                                cond,
+                                "error"
+                                    | "empty"
+                                    | "large"
+                                    | "diff"
+                                    | "status"
+                                    | "log"
+                                    | "show"
+                                    | "build"
+                                    | "test"
+                                    | "check"
+                                    | "clippy"
+                                    | "run"
+                                    | "install"
+                                    | "audit"
+                                    | "ps"
+                                    | "images"
+                            ) {
                                 // Only warn for known condition suffixes that look wrong
                                 // This is a heuristic — subcommand names are open-ended
                             }

--- a/crates/lowfat/src/commands/filter.rs
+++ b/crates/lowfat/src/commands/filter.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use lowfat_core::level::Level;
 use lowfat_core::lf::{self, ExecCtx, ExplainTrace, RuleSet};
 use lowfat_core::tokens::estimate_tokens;
@@ -20,9 +20,8 @@ pub fn run(
     exit_code: i32,
     explain: bool,
 ) -> Result<()> {
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {path}"))?;
-    let rs = lf::parse(&source).with_context(|| format!("parsing {path}"))?;
+    // `lf::load` reads the file and resolves any `include` directives.
+    let rs = lf::load(std::path::Path::new(path)).with_context(|| format!("parsing {path}"))?;
     let level: Level = level_str
         .parse()
         .map_err(|e: String| anyhow!("invalid --level: {e}"))?;
@@ -45,14 +44,13 @@ pub fn run(
     };
 
     if explain {
-        let (out, trace) = lf::execute_explain(&rs, &ctx, &input)
-            .with_context(|| format!("executing {path}"))?;
+        let (out, trace) =
+            lf::execute_explain(&rs, &ctx, &input).with_context(|| format!("executing {path}"))?;
         print_explain(&rs, &ctx, &trace, &input, &out);
         let mut stdout = std::io::stdout();
         stdout.write_all(out.as_bytes())?;
     } else {
-        let out = lf::execute(&rs, &ctx, &input)
-            .with_context(|| format!("executing {path}"))?;
+        let out = lf::execute(&rs, &ctx, &input).with_context(|| format!("executing {path}"))?;
         let mut stdout = std::io::stdout();
         stdout.write_all(out.as_bytes())?;
     }

--- a/crates/lowfat/src/commands/filters.rs
+++ b/crates/lowfat/src/commands/filters.rs
@@ -56,9 +56,7 @@ fn format_filters(config: &RunfConfig, plugins: &[DiscoveredPlugin]) -> String {
     }
 
     // Split bundled (embedded into the binary) from disk-installed for display.
-    let (bundled, community): (Vec<_>, Vec<_>) = plugins
-        .iter()
-        .partition(|p| p.is_embedded());
+    let (bundled, community): (Vec<_>, Vec<_>) = plugins.iter().partition(|p| p.is_embedded());
 
     if !bundled.is_empty() {
         writeln!(out, "  bundled:").unwrap();
@@ -136,7 +134,9 @@ mod tests {
     /// `discover_plugins(empty_dir)` yields (git/docker/ls fall back to the
     /// bundled set when nothing's on disk).
     fn render_with_bundled(config: &RunfConfig) -> String {
-        let plugins = lowfat_plugin::discovery::discover_plugins(std::path::Path::new("/nonexistent-dir-for-test"));
+        let plugins = lowfat_plugin::discovery::discover_plugins(std::path::Path::new(
+            "/nonexistent-dir-for-test",
+        ));
         format_filters(config, &plugins)
     }
 
@@ -181,7 +181,10 @@ mod tests {
         let config = default_config();
         let output = render_with_bundled(&config);
         let git_count = output.matches("git-compact").count();
-        assert_eq!(git_count, 1, "git-compact should appear once, got {git_count}");
+        assert_eq!(
+            git_count, 1,
+            "git-compact should appear once, got {git_count}"
+        );
     }
 
     #[test]

--- a/crates/lowfat/src/commands/gain.rs
+++ b/crates/lowfat/src/commands/gain.rs
@@ -66,10 +66,7 @@ pub fn run() -> Result<()> {
 
     // Summary stats
     let color = savings_color(summary.savings_pct);
-    println!(
-        "  {DIM}commands{RESET}  {BOLD}{}{RESET}",
-        summary.commands,
-    );
+    println!("  {DIM}commands{RESET}  {BOLD}{}{RESET}", summary.commands,);
     println!(
         "  {DIM}input{RESET}    {BOLD}{}{RESET} {DIM}tokens{RESET}",
         fmt_tokens(summary.input_tokens),
@@ -88,9 +85,7 @@ pub fn run() -> Result<()> {
         "           {}",
         bar(summary.input_tokens, summary.output_tokens, 30)
     );
-    println!(
-        "           {GREEN}█ saved{RESET}  {CYAN}░ kept{RESET}"
-    );
+    println!("           {GREEN}█ saved{RESET}  {CYAN}░ kept{RESET}");
     println!();
 
     // Top commands

--- a/crates/lowfat/src/commands/history_prune.rs
+++ b/crates/lowfat/src/commands/history_prune.rs
@@ -20,7 +20,11 @@ pub fn run(opts: PruneOpts) -> Result<()> {
     let db = Db::open(&config.data_dir)?;
     let affected = db.prune_invocations(&filter, opts.dry_run)?;
 
-    let verb = if opts.dry_run { "would remove" } else { "removed" };
+    let verb = if opts.dry_run {
+        "would remove"
+    } else {
+        "removed"
+    };
     println!(
         "lowfat: {verb} {affected} invocation row{s} ({desc})",
         s = if affected == 1 { "" } else { "s" },

--- a/crates/lowfat/src/commands/hook.rs
+++ b/crates/lowfat/src/commands/hook.rs
@@ -55,9 +55,9 @@ mod tests {
         // Discover from a deliberately-empty disk dir so we exercise only the
         // embedded plugins (git/docker/ls). Real callers use the resolved
         // plugin_dir.
-        let plugins = lowfat_plugin::discovery::discover_plugins(
-            std::path::Path::new("/nonexistent-dir-for-test"),
-        );
+        let plugins = lowfat_plugin::discovery::discover_plugins(std::path::Path::new(
+            "/nonexistent-dir-for-test",
+        ));
         let map = lowfat_plugin::discovery::resolve_plugins(&plugins);
         if map.contains_key(base_cmd) {
             Some(format!("lowfat {command}"))

--- a/crates/lowfat/src/commands/level.rs
+++ b/crates/lowfat/src/commands/level.rs
@@ -5,9 +5,7 @@ use lowfat_core::level::Level;
 pub fn run(value: Option<&str>) -> Result<()> {
     match value {
         Some(v) => {
-            let level: Level = v
-                .parse()
-                .map_err(|e: String| anyhow::anyhow!(e))?;
+            let level: Level = v.parse().map_err(|e: String| anyhow::anyhow!(e))?;
             println!("lowfat: level set to {level}");
             println!("  (export LOWFAT_LEVEL={level} to persist in this shell)");
         }

--- a/crates/lowfat/src/commands/mod.rs
+++ b/crates/lowfat/src/commands/mod.rs
@@ -1,10 +1,10 @@
 pub mod audit;
+pub mod candidates;
 pub mod config;
 pub mod filter;
 pub mod filters;
 pub mod gain;
 pub mod help;
-pub mod candidates;
 pub mod history_export;
 pub mod history_prune;
 pub mod hook;

--- a/crates/lowfat/src/commands/opencode.rs
+++ b/crates/lowfat/src/commands/opencode.rs
@@ -17,7 +17,10 @@ fn plugin_path() -> Result<PathBuf> {
             .context("cannot resolve config home (set $HOME or $XDG_CONFIG_HOME)")?
             .join(".config"),
     };
-    Ok(config_home.join("opencode").join("plugins").join("lowfat.ts"))
+    Ok(config_home
+        .join("opencode")
+        .join("plugins")
+        .join("lowfat.ts"))
 }
 
 fn home_dir() -> Option<PathBuf> {
@@ -31,8 +34,7 @@ fn home_dir() -> Option<PathBuf> {
 pub fn install() -> Result<()> {
     let path = plugin_path()?;
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("create {}", parent.display()))?;
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
     fs::write(&path, PLUGIN_TS).with_context(|| format!("write {}", path.display()))?;
 

--- a/crates/lowfat/src/commands/plugin.rs
+++ b/crates/lowfat/src/commands/plugin.rs
@@ -51,7 +51,11 @@ pub fn collect_bench_rows(plugin: &DiscoveredPlugin) -> Result<Vec<BenchRow>> {
 
     for entry in &entries {
         let path = entry.path();
-        let sample_name = path.file_stem().unwrap_or_default().to_string_lossy().to_string();
+        let sample_name = path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
 
         // <command>-<subcommand>-<level>; shorter forms default to level=full.
         let parts: Vec<&str> = sample_name.split('-').collect();
@@ -112,11 +116,13 @@ pub fn list() -> Result<()> {
         let version = m.plugin.version.as_deref().unwrap_or("?");
         let cmds = m.plugin.commands.join(", ");
         let category = &plugin.category;
-        let tag = if plugin.is_embedded() { " (bundled)" } else { "" };
+        let tag = if plugin.is_embedded() {
+            " (bundled)"
+        } else {
+            ""
+        };
 
-        println!(
-            "  {category}/{name} v{version}{tag} — commands: [{cmds}]"
-        );
+        println!("  {category}/{name} v{version}{tag} — commands: [{cmds}]");
     }
 
     Ok(())
@@ -147,35 +153,26 @@ pub fn doctor() -> Result<()> {
             needs_uv = true;
         }
 
-        // Resolve the .lf source — either from the embedded binary blob or
-        // by reading the entry file from disk.
-        let (source, is_lf) = match &plugin.source {
-            lowfat_plugin::discovery::PluginSource::Embedded { filter_lf } => {
-                (filter_lf.to_string(), true)
-            }
+        // Parse the .lf into a RuleSet — embedded blobs parse as a string;
+        // disk files go through `lf::load` so `include` directives resolve.
+        let parsed = match &plugin.source {
+            lowfat_plugin::discovery::PluginSource::Embedded { filter_lf } => lf::parse(filter_lf),
             lowfat_plugin::discovery::PluginSource::Disk { base_dir } => {
                 let entry_path = base_dir.join(plugin.manifest.runtime.resolve_entry(base_dir));
                 if !entry_path.exists() {
                     println!("  {name:<24} x entry not found: {}", entry_path.display());
                     continue;
                 }
-                let is_lf = entry_path.extension().map(|e| e == "lf").unwrap_or(false);
-                if !is_lf {
+                if entry_path.extension().map(|e| e == "lf").unwrap_or(false) {
+                    lf::load(&entry_path)
+                } else {
                     println!("  {name:<24} ok (shell)");
                     ready += 1;
                     continue;
                 }
-                match std::fs::read_to_string(&entry_path) {
-                    Ok(s) => (s, true),
-                    Err(e) => {
-                        println!("  {name:<24} x cannot read: {e}");
-                        continue;
-                    }
-                }
             }
         };
-        let _ = is_lf;
-        let rs = match lf::parse(&source) {
+        let rs = match parsed {
             Ok(r) => r,
             Err(e) => {
                 println!("  {name:<24} x parse error: {e:#}");
@@ -203,10 +200,7 @@ pub fn doctor() -> Result<()> {
             match prewarm_uv(body) {
                 Ok(_) => prewarmed += 1,
                 Err(e) => {
-                    println!(
-                        "  {name:<24} x PEP 723 body #{}: {e:#}",
-                        i + 1
-                    );
+                    println!("  {name:<24} x PEP 723 body #{}: {e:#}", i + 1);
                     all_ok = false;
                     break;
                 }
@@ -319,21 +313,30 @@ pub fn info(name: &str) -> Result<()> {
     let config = RunfConfig::resolve();
     let plugins = discover_plugins(&config.plugin_dir);
 
-    let plugin = plugins
-        .iter()
-        .find(|p| p.manifest.plugin.name == name);
+    let plugin = plugins.iter().find(|p| p.manifest.plugin.name == name);
 
     match plugin {
         Some(p) => {
             let m = &p.manifest;
             println!("Plugin: {}", m.plugin.name);
-            println!("  Version:     {}", m.plugin.version.as_deref().unwrap_or("?"));
-            println!("  Description: {}", m.plugin.description.as_deref().unwrap_or("-"));
-            println!("  Author:      {}", m.plugin.author.as_deref().unwrap_or("-"));
+            println!(
+                "  Version:     {}",
+                m.plugin.version.as_deref().unwrap_or("?")
+            );
+            println!(
+                "  Description: {}",
+                m.plugin.description.as_deref().unwrap_or("-")
+            );
+            println!(
+                "  Author:      {}",
+                m.plugin.author.as_deref().unwrap_or("-")
+            );
             println!("  Category:    {}", p.category);
             let base_dir = p.base_dir();
             let entry = match &p.source {
-                lowfat_plugin::discovery::PluginSource::Embedded { .. } => "filter.lf (embedded)".to_string(),
+                lowfat_plugin::discovery::PluginSource::Embedded { .. } => {
+                    "filter.lf (embedded)".to_string()
+                }
                 lowfat_plugin::discovery::PluginSource::Disk { base_dir } => {
                     m.runtime.resolve_entry(base_dir)
                 }
@@ -435,9 +438,7 @@ pub fn bench(name: &str) -> Result<()> {
     let config = RunfConfig::resolve();
     let plugins = discover_plugins(&config.plugin_dir);
 
-    let plugin = plugins
-        .iter()
-        .find(|p| p.manifest.plugin.name == name);
+    let plugin = plugins.iter().find(|p| p.manifest.plugin.name == name);
 
     let plugin = match plugin {
         Some(p) => p,
@@ -533,6 +534,9 @@ subcommands = ["run"]
             row.filtered_tokens > 0,
             "filter.lf must run through LfFilter (in-process), not sh — got 0 tokens"
         );
-        assert!(row.filtered_tokens < row.raw_tokens, "head 2 trims the 5-line sample");
+        assert!(
+            row.filtered_tokens < row.raw_tokens,
+            "head 2 trims the 5-line sample"
+        );
     }
 }

--- a/crates/lowfat/src/commands/post_read.rs
+++ b/crates/lowfat/src/commands/post_read.rs
@@ -15,8 +15,7 @@ pub fn run() -> Result<()> {
 }
 
 fn process_payload(input: &str) -> Result<()> {
-    let payload: Value =
-        serde_json::from_str(input).context("Failed to parse PostToolUse JSON")?;
+    let payload: Value = serde_json::from_str(input).context("Failed to parse PostToolUse JSON")?;
 
     // Read tool delivers content as a structured object:
     //   tool_response: { type: "text", file: { content, numLines, totalLines, ... } }
@@ -100,7 +99,12 @@ mod tests {
         // and that real-shaped lock content is handled. Shape correctness is covered
         // by the field paths in process_payload (tool_response.file.content).
         let lock_content = (0..50)
-            .map(|i| format!("[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n", i, i))
+            .map(|i| {
+                format!(
+                    "[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n",
+                    i, i
+                )
+            })
             .collect::<String>();
         let payload = make_payload("Cargo.lock", &lock_content);
         assert!(process_payload(&payload).is_ok());
@@ -117,7 +121,12 @@ mod tests {
     fn lock_file_compresses() {
         // Lock files get extreme summarization — guaranteed >10% savings
         let lock_content = (0..50)
-            .map(|i| format!("[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n", i, i))
+            .map(|i| {
+                format!(
+                    "[[package]]\nname = \"pkg-{}\"\nversion = \"1.0.{}\"\n",
+                    i, i
+                )
+            })
             .collect::<String>();
         let payload = make_payload("Cargo.lock", &lock_content);
         assert!(process_payload(&payload).is_ok());

--- a/crates/lowfat/src/commands/run.rs
+++ b/crates/lowfat/src/commands/run.rs
@@ -79,8 +79,15 @@ pub fn run(args: &[String]) -> i32 {
     );
     let filter_name = resolved.as_ref().map(|(name, _)| name.clone());
     let is_external_plugin = resolved.map(|(_, ext)| ext).unwrap_or(false);
-    let pipeline = resolve_pipeline(cmd, exit_code, &raw, &config, &filter_name,
-        &external_plugins, &external_map);
+    let pipeline = resolve_pipeline(
+        cmd,
+        exit_code,
+        &raw,
+        &config,
+        &filter_name,
+        &external_plugins,
+        &external_map,
+    );
 
     // Build plugin map for pipeline execution: builtins + loaded community plugins
     let mut plugin_map: HashMap<String, Box<dyn FilterPlugin>> = all_filters;
@@ -95,10 +102,10 @@ pub fn run(args: &[String]) -> i32 {
         }
     }
     for stage in &pipeline.stages {
-        if stage.stage_type == StageType::Plugin
-            && !plugin_map.contains_key(&stage.name)
-        {
-            if let Some(loaded) = load_external_plugin(&stage.name, &external_plugins, &external_map) {
+        if stage.stage_type == StageType::Plugin && !plugin_map.contains_key(&stage.name) {
+            if let Some(loaded) =
+                load_external_plugin(&stage.name, &external_plugins, &external_map)
+            {
                 plugin_map.insert(stage.name.clone(), loaded);
             }
         }
@@ -140,8 +147,8 @@ pub fn run(args: &[String]) -> i32 {
         let known = known_subcommands(cmd, &plugin_map, &external_plugins, &external_map);
         // in_scope = plugin is declared to handle *this* subcommand. Empty
         // `known` means "no subcommand restriction" — treat as universal.
-        let in_scope = filter_name.is_some()
-            && (known.is_empty() || known.iter().any(|s| s == &subcommand));
+        let in_scope =
+            filter_name.is_some() && (known.is_empty() || known.iter().any(|s| s == &subcommand));
         let raw_tokens = lowfat_core::tokens::estimate_tokens(&raw) as u64;
         let filtered_tokens = lowfat_core::tokens::estimate_tokens(&filtered) as u64;
         let _ = db.record_invocation(&InvocationRecord {
@@ -207,7 +214,8 @@ fn resolve_pipeline(
     plugins: &[DiscoveredPlugin],
     cmd_map: &HashMap<String, usize>,
 ) -> Pipeline {
-    let mut base = resolve_base_pipeline(cmd, exit_code, raw, config, filter_name, plugins, cmd_map);
+    let mut base =
+        resolve_base_pipeline(cmd, exit_code, raw, config, filter_name, plugins, cmd_map);
 
     // Prepend `pipeline.* = ...` stages. The `cmd != "*"` guard is paranoia
     // for someone literally running a command named `*`.
@@ -429,7 +437,10 @@ mod tests {
                 Some((c, cond)) => (c.to_string(), cond.to_string()),
                 None => (key.to_string(), String::new()),
             };
-            by_cmd.entry(cmd).or_default().push((cond, spec.to_string()));
+            by_cmd
+                .entry(cmd)
+                .or_default()
+                .push((cond, spec.to_string()));
         }
         for (cmd, ls) in by_cmd {
             pipelines.insert(cmd, parse_conditional_pipeline(&ls));

--- a/crates/lowfat/src/commands/shell_init.rs
+++ b/crates/lowfat/src/commands/shell_init.rs
@@ -18,7 +18,8 @@ pub fn run(shell: &str) -> Result<()> {
 }
 
 fn print_posix_init() {
-    print!(r#"# lowfat shell init — auto-wrap commands for LLM token savings
+    print!(
+        r#"# lowfat shell init — auto-wrap commands for LLM token savings
 # Usage: eval "$(lowfat shell-init zsh)"
 
 if [[ "$CLAUDECODE" == "1" ]] || [[ -n "$CODEX_ENV" ]] || [[ "$LOWFAT_ENABLE" == "1" ]]; then
@@ -27,11 +28,13 @@ if [[ "$CLAUDECODE" == "1" ]] || [[ -n "$CODEX_ENV" ]] || [[ "$LOWFAT_ENABLE" ==
   done
   unset _lf_cmd
 fi
-"#);
+"#
+    );
 }
 
 fn print_fish_init() {
-    print!(r#"# lowfat shell init for fish
+    print!(
+        r#"# lowfat shell init for fish
 # Usage: lowfat shell-init fish | source
 
 if test "$CLAUDECODE" = 1; or test -n "$CODEX_ENV"; or test "$LOWFAT_ENABLE" = 1
@@ -39,5 +42,6 @@ if test "$CLAUDECODE" = 1; or test -n "$CODEX_ENV"; or test "$LOWFAT_ENABLE" = 1
     eval "function $cmd; command lowfat $cmd \$argv; end"
   end
 end
-"#);
+"#
+    );
 }

--- a/crates/lowfat/src/commands/status.rs
+++ b/crates/lowfat/src/commands/status.rs
@@ -35,12 +35,8 @@ pub fn run() -> Result<()> {
     const R: &str = "\x1b[0m";
 
     println!();
-    println!(
-        "  {Y}💰{R} {D}saved:{R} {B}{input}{R} {D}→{R} {G}{B}{output}{R} {D}tokens{R}"
-    );
-    println!(
-        "  {Y}⚡{R} {D}speed:{R} {B}{time_without:.1}s{R} {D}→{R} {G}{B}{time_s:.1}s{R}"
-    );
+    println!("  {Y}💰{R} {D}saved:{R} {B}{input}{R} {D}→{R} {G}{B}{output}{R} {D}tokens{R}");
+    println!("  {Y}⚡{R} {D}speed:{R} {B}{time_without:.1}s{R} {D}→{R} {G}{B}{time_s:.1}s{R}");
     println!();
 
     Ok(())

--- a/crates/lowfat/src/main.rs
+++ b/crates/lowfat/src/main.rs
@@ -227,12 +227,8 @@ fn main() {
 
     let result = match cli.command {
         // ── new consolidated inspection commands ─────────────────
-        Some(Commands::Info { cmd, config }) => {
-            commands::info::run(cmd.as_deref(), config)
-        }
-        Some(Commands::Stats { audit, audit_limit }) => {
-            commands::stats::run(audit, audit_limit)
-        }
+        Some(Commands::Info { cmd, config }) => commands::info::run(cmd.as_deref(), config),
+        Some(Commands::Stats { audit, audit_limit }) => commands::stats::run(audit, audit_limit),
 
         // ── kept ─────────────────────────────────────────────────
         Some(Commands::History { limit, all, action }) => match action {
@@ -287,7 +283,9 @@ fn main() {
         Some(Commands::Config) => commands::info::run(None, true),
         Some(Commands::Status) => commands::info::run(None, false),
         Some(Commands::Pipeline { cmd }) => commands::info::run(Some(&cmd), false),
-        Some(Commands::Filters { commands: cmds_only }) => {
+        Some(Commands::Filters {
+            commands: cmds_only,
+        }) => {
             // `--commands` is consumed by shell-init scripts; preserve its
             // raw one-per-line output. Bare form is just a view of `info`.
             if cmds_only {

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -139,6 +139,27 @@ diff:           compact-diff 200
 strip-trailers              # zero-arg call
 ```
 
+## Sharing macros: `include`
+
+Pull another file's `define`s into the current file so wrappers can reuse a
+tool's compaction instead of copying it:
+
+```awk
+include lib/pytest.lf       # path is relative to THIS file
+
+*:
+    compact-pytest 45       # macro defined in lib/pytest.lf
+```
+
+- **Macros only.** Rules in an included file are ignored, so a real filter can
+  also serve as a library.
+- **Path is relative to the including file**; transitive includes work.
+- **Override by redefining.** A local `define` with the same name shadows the
+  imported one — handy to tweak a single inherited macro.
+- **Collisions error.** The same name imported from two different files is a
+  hard error (rename one, or override it locally). Cycles are rejected.
+- Only files loaded from disk can `include` — embedded/bundled filters can't.
+
 ## Inline ops on a rule header
 
 ```awk

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -46,7 +46,7 @@ subcommands = ["get", "describe", "logs", "apply"]
 
 # The lf-filter DSL
 
-**lf-filter** is lowfat's declarative plugin DSL. A `.lf` file is a sequence of `define` blocks and `rule` blocks; the runner picks the first rule whose selector matches `(subcommand, level)` and runs its ops top-to-bottom.
+**lf-filter** is lowfat's declarative plugin DSL. A `.lf` file is a sequence of `include` directives, `define` blocks, and `rule` blocks; the runner picks the first rule whose selector matches `(subcommand, level)` and runs its ops top-to-bottom.
 
 ## Selectors
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -160,6 +160,8 @@ include lib/pytest.lf       # path is relative to THIS file
   hard error (rename one, or override it locally). Cycles are rejected.
 - Only files loaded from disk can `include` — embedded/bundled filters can't.
 
+Runnable example: [`examples/include`](../examples/include).
+
 ## Inline ops on a rule header
 
 ```awk

--- a/examples/include/README.md
+++ b/examples/include/README.md
@@ -1,0 +1,25 @@
+# `include` example
+
+`uv run pytest` produces the same output as `pytest`, so its wrapper filter
+reuses pytest's compaction macro instead of copying it.
+
+```
+lib/pytest.lf     defines `compact-pytest` (and is a runnable pytest filter)
+uv-pytest.lf      includes lib/pytest.lf, reuses `compact-pytest`
+```
+
+Run it:
+
+```sh
+lowfat filter uv-pytest.lf --sub run < sample-pytest.txt
+```
+
+The wrapper keeps the verdicts and the summary banner, dropping the noise — all
+from a macro defined in another file. See `--explain` for per-stage counts:
+
+```sh
+lowfat filter uv-pytest.lf --sub run --explain < sample-pytest.txt
+```
+
+See [docs/PLUGINS.md](../../docs/PLUGINS.md#sharing-macros-include) for the rules
+(relative paths, transitive includes, local override, collision errors).

--- a/examples/include/lib/pytest.lf
+++ b/examples/include/lib/pytest.lf
@@ -1,0 +1,12 @@
+#!/usr/bin/env lowfat-filter
+# pytest.lf — compacts `pytest` output. Doubles as a macro library: other
+# filters can `include` it to reuse `compact-pytest` (its rules are ignored
+# on include).
+
+# Keep the test verdicts + section banners, drop the noise, then cap.
+define compact-pytest:
+    keep /PASSED|FAILED|ERROR|=====|passed|failed|error/
+    head 40
+
+pytest:
+    compact-pytest

--- a/examples/include/sample-pytest.txt
+++ b/examples/include/sample-pytest.txt
@@ -1,0 +1,18 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.0, pytest-8.0.0, pluggy-1.4.0
+rootdir: /home/user/project
+collected 3 items
+
+tests/test_foo.py::test_a PASSED                                         [ 33%]
+tests/test_foo.py::test_b FAILED                                         [ 66%]
+tests/test_foo.py::test_c PASSED                                         [100%]
+
+=================================== FAILURES ===================================
+___________________________________ test_b ____________________________________
+
+    def test_b():
+>       assert add(2, 2) == 5
+E       assert 4 == 5
+
+tests/test_foo.py:9: AssertionError
+=========================== 2 passed, 1 failed in 0.51s ========================

--- a/examples/include/uv-pytest.lf
+++ b/examples/include/uv-pytest.lf
@@ -1,0 +1,8 @@
+#!/usr/bin/env lowfat-filter
+# uv-pytest.lf — wraps `uv run pytest`. The output is pytest's, so reuse
+# pytest's compaction instead of copying it. Path is relative to this file.
+include lib/pytest.lf
+
+# `uv run pytest` → subcommand is `run`.
+run:
+    compact-pytest


### PR DESCRIPTION
## What

Adds an `include other.lf` directive so one filter can reuse another's `define`d macros instead of copying them. (https://github.com/zdk/lowfat/issues/14)

```awk
include lib/pytest.lf       # path relative to THIS file
run:
    compact-pytest          # macro defined in lib/pytest.lf
```

## Design

Include resolution is a single new loader layer — `lf::load(path)`. It reads the include graph, merges every file's `define`s, then hands the parser the complete macro vocabulary. **Includes never enter the `Op`/`RuleSet` AST**, so the executor, explain trace, and PEP-723 scan are untouched.

- Paths resolve **relative to the including file**; transitive includes work.
- **Diamond dedup** via `(name, origin)` — same macro reached two ways is one macro, not a collision.
- **Cross-file name collision** is a hard error naming both files; **cycles** rejected with the chain.
- **Local `define` overrides** an inherited one of the same name.
- Included files' **rules are ignored** — a real filter can double as a macro library.
- Bare `lf::parse` (embedded filters, tests) **errors** on `include` — no base dir to resolve against.

## Callers

`LfFilter::load`, `lowfat filter`, and `lowfat plugin doctor` now use `lf::load` for disk files. Embedded (`&'static str`) filters keep `parse` — no filesystem location.

## Docs & example

- `docs/PLUGINS.md`: overview line + dedicated `include` section.
- `examples/include/`: runnable `uv run pytest` wrapper that includes `lib/pytest.lf`.

## Tests

- 11 loader unit tests: basic / relative / transitive / diamond / cycle / collision / override / quoted-path / missing / rules-ignored / bare-parse-reject.
- `include_example_resolves_and_runs`: e2e test that loads the example via `lf::load`, executes it, and asserts the imported macro actually runs. 